### PR TITLE
Default to base for ATXPAccount, better logging

### DIFF
--- a/packages/atxp-client/src/atxpAccount.ts
+++ b/packages/atxp-client/src/atxpAccount.ts
@@ -1,5 +1,5 @@
 import type { Account, PaymentMaker } from './types.js';
-import type { FetchLike } from '@atxp/common'
+import type { FetchLike, Network } from '@atxp/common'
 import BigNumber from 'bignumber.js';
 
 function toBasicAuth(token: string): string {
@@ -83,10 +83,10 @@ export class ATXPAccount implements Account {
   accountId: string;
   paymentMakers: { [key: string]: PaymentMaker };
 
-  constructor(connectionString: string, opts?: { fetchFn?: FetchLike; network?: string }) {
+  constructor(connectionString: string, opts?: { fetchFn?: FetchLike; network?: Network }) {
     const { origin, token } = parseConnectionString(connectionString);
     const fetchFn = opts?.fetchFn ?? fetch;
-    const network = opts?.network ?? 'solana';
+    const network = opts?.network ?? 'base';
 
     // Use token as a stable accountId namespace to keep OAuth/ATXP state per-connection
     this.accountId = `atxp:${token}`;
@@ -95,5 +95,3 @@ export class ATXPAccount implements Account {
     };
   }
 }
-
-

--- a/packages/atxp-client/src/atxpFetcher.ts
+++ b/packages/atxp-client/src/atxpFetcher.ts
@@ -140,7 +140,7 @@ export class ATXPFetcher {
 
     const paymentMaker = this.paymentMakers.get(requestedNetwork);
     if (!paymentMaker) {
-      this.logger.info(`ATXP: payment network ${requestedNetwork} not set up for this server (available networks: ${Array.from(this.paymentMakers.keys()).join(', ')})`);
+      this.logger.info(`ATXP: payment network '${requestedNetwork}' not set up for this client (available networks: ${Array.from(this.paymentMakers.keys()).join(', ')})`);
       return false;
     }
 

--- a/src/dev/cli.ts
+++ b/src/dev/cli.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { atxpClient, BaseAccount } from '@atxp/client';
+import { atxpClient, ATXPAccount } from '@atxp/client';
 import { ConsoleLogger, LogLevel } from '@atxp/common';
 import 'dotenv/config';
 
@@ -47,8 +47,8 @@ async function main() {
     validateEnv();
 
     //const account = new SolanaAccount(process.env.SOLANA_ENDPOINT!, process.env.SOLANA_PRIVATE_KEY!);
-    //const account = new ATXPAccount(process.env.ATXP_CONNECTION_STRING!);
-    const account = new BaseAccount(process.env.BASE_RPC!, process.env.BASE_PRIVATE_KEY! as `0x${string}`);
+    const account = new ATXPAccount(process.env.ATXP_CONNECTION_STRING!);
+    //const account = new BaseAccount(process.env.BASE_RPC!, process.env.BASE_PRIVATE_KEY! as `0x${string}`);
     const mcpClient = await atxpClient({
       mcpServer: url,
       account,


### PR DESCRIPTION
Also updates `npm run dev:cli` to use `ATXPAccount` for testing/validation