### PR TITLE
Payment error msg: guide users to retry

### DIFF
--- a/packages/atxp-common/src/paymentRequiredError.ts
+++ b/packages/atxp-common/src/paymentRequiredError.ts
@@ -14,5 +14,5 @@ export function paymentRequiredError(server: AuthorizationServerUrl, paymentRequ
   const paymentRequestUrl = `${server}/payment-request/${paymentRequestId}`;
   const data = { paymentRequestId, paymentRequestUrl, chargeAmount };
   const amountText = chargeAmount ? ` You will be charged ${chargeAmount.toString()}.` : '';
-  return new McpError(PAYMENT_REQUIRED_ERROR_CODE, `${PAYMENT_REQUIRED_PREAMBLE}${amountText} Please pay at: ${paymentRequestUrl}`, data);
+  return new McpError(PAYMENT_REQUIRED_ERROR_CODE, `${PAYMENT_REQUIRED_PREAMBLE}${amountText} Please pay at: ${paymentRequestUrl} and then try again.`, data);
 } 


### PR DESCRIPTION
Slight tweak to the human-visible payment-required message to ask them to retry after making a payment at the indicated URL.