### PR TITLE
Standardize on Currency

### DIFF
--- a/packages/atxp-client/src/atxpAccount.ts
+++ b/packages/atxp-client/src/atxpAccount.ts
@@ -1,5 +1,5 @@
 import type { Account, PaymentMaker } from './types.js';
-import type { FetchLike, Network } from '@atxp/common'
+import type { FetchLike, Network, Currency } from '@atxp/common'
 import BigNumber from 'bignumber.js';
 
 function toBasicAuth(token: string): string {
@@ -29,10 +29,10 @@ class ATXPHttpPaymentMaker implements PaymentMaker {
     this.fetchFn = fetchFn;
   }
 
-  async makePayment(amount: BigNumber, currency: string, receiver: string, memo: string): Promise<string> {
+  async makePayment(amount: BigNumber, currency: Currency, receiver: string, memo: string): Promise<string> {
     const body = {
       amount: amount.toString(),
-      currency: (currency || '').toLowerCase() === 'usdc' ? 'usdc' : 'usdc',
+      currency,
       receiver,
       memo,
     };

--- a/packages/atxp-client/src/basePaymentMaker.ts
+++ b/packages/atxp-client/src/basePaymentMaker.ts
@@ -1,5 +1,5 @@
 import type { PaymentMaker } from './types.js';
-import { Logger } from '@atxp/common';
+import { Logger, Currency } from '@atxp/common';
 import { ConsoleLogger } from '@atxp/common';
 import {
   Address,
@@ -100,10 +100,9 @@ export class BasePaymentMaker implements PaymentMaker {
     return `${header}.${payload}.${signature}`;
   }
 
-  makePayment = async (amount: BigNumber, currency: string, receiver: string): Promise<string> => {
-    currency = currency.toLowerCase();
-    if (currency !== 'usdc') {
-      throw new Error('Only usdc currency is supported; received ' + currency);
+  makePayment = async (amount: BigNumber, currency: Currency, receiver: string): Promise<string> => {
+    if (currency.toUpperCase() !== 'USDC') {
+      throw new Error('Only USDC currency is supported; received ' + currency);
     }
 
     this.logger.info(`Making payment of ${amount} ${currency} to ${receiver} on Base`);

--- a/packages/atxp-client/src/solanaPaymentMaker.ts
+++ b/packages/atxp-client/src/solanaPaymentMaker.ts
@@ -3,7 +3,7 @@ import { Keypair, Connection, PublicKey, ComputeBudgetProgram, sendAndConfirmTra
 import { createTransfer, ValidateTransferError as _ValidateTransferError } from "@solana/pay";
 import bs58 from "bs58";
 import BigNumber from "bignumber.js";
-import { generateJWT } from '@atxp/common';
+import { generateJWT, Currency } from '@atxp/common';
 import { importJWK } from 'jose';
 import { Logger } from '@atxp/common';
 import { ConsoleLogger } from '@atxp/common';
@@ -47,10 +47,9 @@ export class SolanaPaymentMaker implements PaymentMaker {
     return generateJWT(this.source.publicKey.toBase58(), privateKey, paymentRequestId || '', codeChallenge || '');
   }
 
-  makePayment = async (amount: BigNumber, currency: string, receiver: string): Promise<string> => {
-    currency = currency.toLowerCase();
-    if (currency !== 'usdc') {
-      throw new Error('Only usdc currency is supported; received ' + currency);
+  makePayment = async (amount: BigNumber, currency: Currency, receiver: string): Promise<string> => {
+    if (currency.toUpperCase() !== 'USDC') {
+      throw new Error('Only USDC currency is supported; received ' + currency);
     }
 
     const receiverKey = new PublicKey(receiver);

--- a/packages/atxp-client/src/types.ts
+++ b/packages/atxp-client/src/types.ts
@@ -40,6 +40,6 @@ export type ClientConfig = {
 }
 
 export interface PaymentMaker {
-  makePayment: (amount: BigNumber, currency: string, receiver: string, memo: string) => Promise<string>;
+  makePayment: (amount: BigNumber, currency: Currency, receiver: string, memo: string) => Promise<string>;
   generateJWT: (params: {paymentRequestId: string, codeChallenge: string}) => Promise<string>;
 }


### PR DESCRIPTION
Make sure we're using the enum for indicating currency to avoid case issues.