### PR TITLE
Adds explict typing for base payments

### DIFF
--- a/packages/atxp-client/src/baseAccount.ts
+++ b/packages/atxp-client/src/baseAccount.ts
@@ -1,4 +1,4 @@
-import type { Account, PaymentMaker } from './types.js';
+import type { Account, PaymentMaker, Hex } from './types.js';
 import { privateKeyToAccount } from 'viem/accounts';
 import { BasePaymentMaker } from './basePaymentMaker.js';
 
@@ -6,7 +6,7 @@ export class BaseAccount implements Account {
   accountId: string;
   paymentMakers: { [key: string]: PaymentMaker };
 
-  constructor(baseRPCUrl: string, sourceSecretKey: `0x${string}`) {
+  constructor(baseRPCUrl: string, sourceSecretKey: Hex) {
     if (!baseRPCUrl) {
       throw new Error('Base RPC URL is required');
     }

--- a/packages/atxp-client/src/types.ts
+++ b/packages/atxp-client/src/types.ts
@@ -3,6 +3,9 @@ import { AuthorizationServerUrl, Currency, Logger, Network, OAuthDb, FetchLike }
 import { ClientOptions } from "@modelcontextprotocol/sdk/client/index.js";
 import { Implementation } from "@modelcontextprotocol/sdk/types.js";
 
+// Type definitions for hex strings
+export type Hex = `0x${string}`;
+
 type AccountPrefix = Network;
 export type AccountIdString = `${AccountPrefix}${string}`;
 


### PR DESCRIPTION
# Description

* Added a type for the Hex concept
* Type the wallet client rather than having it be an any.

# Motivation
Cleaning up typing... using `any` means we are not leveraging Typescript and are unaware if the library changes underneath us.