### PR TITLE
Send over payee name when making a payment request

### DIFF
--- a/packages/atxp-common/src/types.ts
+++ b/packages/atxp-common/src/types.ts
@@ -30,6 +30,7 @@ export type PaymentRequestData = {
   source: string;
   resource: URL;
   resourceName: string;
+  payeeName?: string | null;
   iss: string;
 }
 

--- a/packages/atxp-server/src/paymentServer.ts
+++ b/packages/atxp-server/src/paymentServer.ts
@@ -1,4 +1,4 @@
-import { PaymentServer, ChargeResponse } from "./types.js";
+import { PaymentServer, ChargeResponse, Charge } from "./types.js";
 import { Network, Currency, AuthorizationServerUrl, FetchLike, Logger, PaymentRequestData } from "@atxp/common";
 import BigNumber from "bignumber.js";
 
@@ -50,10 +50,8 @@ export class ATXPPaymentServer implements PaymentServer {
     }
   }
 
-  createPaymentRequest = async({source, destination, network, currency, amount}: 
-    {source: string, destination: string, network: Network, currency: Currency, amount: BigNumber}): Promise<string> => {
-    const body = {source, destination, network, currency, amount};
-    const response = await this.makeRequest('POST', '/payment-request', body);
+  createPaymentRequest = async(charge: Charge): Promise<string> => {
+    const response = await this.makeRequest('POST', '/payment-request', charge);
     const json = await response.json() as {id?: string};
     if (response.status !== 200) {
       this.logger.warn(`POST /payment-request responded with unexpected HTTP status ${response.status}`);

--- a/packages/atxp-server/src/requirePayment.test.ts
+++ b/packages/atxp-server/src/requirePayment.test.ts
@@ -25,6 +25,7 @@ describe('requirePayment', () => {
         network: config.network,
         destination: config.destination,
         source: 'test-user',
+        payeeName: config.payeeName,
       });
     });
   });
@@ -54,7 +55,8 @@ describe('requirePayment', () => {
           currency: config.currency,
           network: config.network,
           destination: config.destination,
-          source: 'test-user'
+          source: 'test-user',
+          payeeName: config.payeeName,
         });
       }
     });

--- a/packages/atxp-server/src/requirePayment.ts
+++ b/packages/atxp-server/src/requirePayment.ts
@@ -17,7 +17,8 @@ export async function requirePayment(paymentConfig: RequirePaymentConfig): Promi
     currency: config.currency, 
     network: config.network, 
     destination: config.destination, 
-    source: user
+    source: user,
+    payeeName: config.payeeName,
   };
 
   config.logger.debug(`Charging amount ${charge.amount}, destination ${charge.destination}, source ${charge.source}`);


### PR DESCRIPTION
# Description
When sending over a payment request, include the payee name for later display on the payment screen

# Motivation
Part of https://linear.app/novellum/issue/NOV-156/human-payment-request-flow-ui-doesnt-show-transaction-info

# Testing
Updated unit tests