### PR TITLE
[NOV-199] Handle wallet_connect not being there

### DIFF
--- a/packages/atxp-base/src/baseAppAccount.ts
+++ b/packages/atxp-base/src/baseAppAccount.ts
@@ -62,6 +62,14 @@ export class BaseAppAccount implements Account {
       }
     });
     const provider = sdk.getProvider();
+    // Some wallets don't support wallet_connect, so 
+    // will just continue if it fails
+    try {
+      await provider.request({ method: 'wallet_connect' });
+    } catch (error) {
+      // Continue if wallet_connect is not supported
+      logger.warn(`wallet_connect not supported, continuing with initialization. ${error}`);
+    }
 
     const privateKey = generatePrivateKey();
     const smartWallet = await toEphemeralSmartWallet(privateKey, config.apiKey);


### PR DESCRIPTION
# Description
In our testing, not all providers supported the `wallet_connect` method. Also, since we are requesting spend permission, it should not be needed

# Testing
Tested with both browser and phone wallets 