### PR TITLE
[ATXP-222] Move log lines with the redirect URL down to debug

### DIFF
--- a/packages/atxp-client/src/atxpFetcher.ts
+++ b/packages/atxp-client/src/atxpFetcher.ts
@@ -279,7 +279,7 @@ export class ATXPFetcher {
     if (response.status >= 300 && response.status < 400) {
       const location = response.headers.get('Location');
       if (location) {
-        this.logger.info(`ATXP: got redirect authorization code response - redirect to ${location}`);
+        this.logger.debug(`ATXP: got redirect authorization code response - redirect to ${location}`);
         return location;
       } else {
         this.logger.info(`ATXP: got redirect authorization code response, but no redirect URL in Location header`);
@@ -291,7 +291,7 @@ export class ATXPFetcher {
       const body = await response.json();
       const redirectUrl = body.redirect;
       if (redirectUrl) {
-        this.logger.info(`ATXP: got response.ok authorization code response - redirect to ${redirectUrl}`);
+        this.logger.debug(`ATXP: got response.ok authorization code response - redirect to ${redirectUrl}`);
         return redirectUrl;
       } else {
         this.logger.info(`ATXP: got authorization code response with response.ok, but no redirect URL in body`);

--- a/packages/atxp-client/src/oAuth.ts
+++ b/packages/atxp-client/src/oAuth.ts
@@ -157,7 +157,8 @@ export class OAuthClient extends OAuthResourceClient {
   }
 
   handleCallback = async (url: string): Promise<void> => {
-    this.logger.info(`Handling authorization code callback: ${url}`);
+    this.logger.info(`Handling authorization code callback`)
+    this.logger.debug(`Callback URL: ${url}`);
 
     const callbackUrl = new URL(url);
     const state = callbackUrl.searchParams.get('state');


### PR DESCRIPTION
# Description
When we make a ATXP Authorization Fetch, we send in a link to localhost as a callback (see https://github.com/atxp-dev/sdk/blob/0550639e0127b40a720d7ef162e3330b4cb6464e/packages/atxp-client/src/atxpFetcher.ts#L71-L72)

However, we do not actually have a server running there. Rather we handle the callback in line. 

We currently have some confusing log lines that highlight the URL. This confuses people. Let's make them debug

# Motivation
https://linear.app/novellum/issue/ATXP-222/confusing-redirect-log-message