### PR TITLE
BaseAccount constructor accepts string type params

### DIFF
--- a/packages/atxp-client/src/baseAccount.ts
+++ b/packages/atxp-client/src/baseAccount.ts
@@ -10,7 +10,7 @@ export class BaseAccount implements Account {
   accountId: string;
   paymentMakers: { [key: string]: PaymentMaker };
 
-  constructor(baseRPCUrl: string, sourceSecretKey: Hex) {
+  constructor(baseRPCUrl: string, sourceSecretKey: string) {
     if (!baseRPCUrl) {
       throw new Error('Base RPC URL is required');
     }
@@ -18,7 +18,7 @@ export class BaseAccount implements Account {
       throw new Error('Source secret key is required');
     }
 
-    const account = privateKeyToAccount(sourceSecretKey);
+    const account = privateKeyToAccount(sourceSecretKey as Hex);
 
     this.accountId = account.address;
     const walletClient = createWalletClient({


### PR DESCRIPTION
This change makes it so that developers don't need to do their own casting of a value that they've presumably read in as a `string` from an env var prior to using it to create a `BaseAccount` object.