### PR TITLE
Pin @base-org/account to exact version 2.0.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14224,7 +14224,7 @@
       "dependencies": {
         "@atxp/client": "0.2.20",
         "@atxp/common": "0.2.20",
-        "@base-org/account": "^2.0.2",
+        "@base-org/account": "2.0.2",
         "bignumber.js": "^9.3.0",
         "viem": "^2.34.0"
       },

--- a/packages/atxp-base/package.json
+++ b/packages/atxp-base/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@atxp/client": "0.2.20",
     "@atxp/common": "0.2.20",
-    "@base-org/account": "^2.0.2",
+    "@base-org/account": "2.0.2",
     "bignumber.js": "^9.3.0",
     "viem": "^2.34.0"
   },


### PR DESCRIPTION
## Summary
In `@base-org/account`, version 2.1.0, there was a change to how some things are imported based on whether they are in browser or node mode. This caused problems with Next.JS installations.

https://github.com/atxp-dev/sdk/pull/36 is working on a permanent fix, but in the meantime,  we will pin the `@base-org/account` dependency to exactly version 2.0.2 to ensure consistent behavior across all installations and prevent potential breaking changes from automatic minor/patch version updates.

## Changes Made
- **Updated `packages/atxp-base/package.json`**: Changed `"@base-org/account": "^2.0.2"` to `"@base-org/account": "2.0.2"`
- **Updated `package-lock.json`**: Reflects the exact version pinning

## Why This Change
- **Stability**: Prevents automatic updates to newer versions that might introduce breaking changes
- **Consistency**: Ensures all developers and deployment environments use exactly the same version
- **Control**: Allows explicit decision-making about when to upgrade this critical dependency

## Testing
- ✅ All 44 tests continue to pass
- ✅ Package builds successfully with the pinned version
- ✅ Verified exact version 2.0.2 is installed: `npm ls @base-org/account`

## Impact
- No functional changes to the codebase
- Same version currently being used, just now pinned exactly
- Future `npm install` commands will use exactly version 2.0.2

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>