### PR TITLE
Add .npmignore files to all packages (ATXP-280)

### DIFF
--- a/packages/atxp-base/.npmignore
+++ b/packages/atxp-base/.npmignore
@@ -1,0 +1,25 @@
+# Source files - only dist should be published
+src/
+
+# Test files
+*.test.ts
+*.spec.ts
+**/*.test.ts
+**/*.spec.ts
+
+# TypeScript configuration
+tsconfig.json
+tsconfig.*.json
+*.tsbuildinfo
+
+# Build and dev configuration
+vitest.config.ts
+*.config.js
+*.config.ts
+
+# Documentation (README.md is included via files array in package.json)
+docs/
+
+# Development files
+.eslintrc*
+.prettierrc*

--- a/packages/atxp-client/.npmignore
+++ b/packages/atxp-client/.npmignore
@@ -1,0 +1,25 @@
+# Source files - only dist should be published
+src/
+
+# Test files
+*.test.ts
+*.spec.ts
+**/*.test.ts
+**/*.spec.ts
+
+# TypeScript configuration
+tsconfig.json
+tsconfig.*.json
+*.tsbuildinfo
+
+# Build and dev configuration
+vitest.config.ts
+*.config.js
+*.config.ts
+
+# Documentation (README.md is included via files array in package.json)
+docs/
+
+# Development files
+.eslintrc*
+.prettierrc*

--- a/packages/atxp-common/.npmignore
+++ b/packages/atxp-common/.npmignore
@@ -1,0 +1,25 @@
+# Source files - only dist should be published
+src/
+
+# Test files
+*.test.ts
+*.spec.ts
+**/*.test.ts
+**/*.spec.ts
+
+# TypeScript configuration
+tsconfig.json
+tsconfig.*.json
+*.tsbuildinfo
+
+# Build and dev configuration
+vitest.config.ts
+*.config.js
+*.config.ts
+
+# Documentation (README.md is included via files array in package.json)
+docs/
+
+# Development files
+.eslintrc*
+.prettierrc*

--- a/packages/atxp-redis/.npmignore
+++ b/packages/atxp-redis/.npmignore
@@ -1,0 +1,25 @@
+# Source files - only dist should be published
+src/
+
+# Test files
+*.test.ts
+*.spec.ts
+**/*.test.ts
+**/*.spec.ts
+
+# TypeScript configuration
+tsconfig.json
+tsconfig.*.json
+*.tsbuildinfo
+
+# Build and dev configuration
+vitest.config.ts
+*.config.js
+*.config.ts
+
+# Documentation (README.md is included via files array in package.json)
+docs/
+
+# Development files
+.eslintrc*
+.prettierrc*

--- a/packages/atxp-server/.npmignore
+++ b/packages/atxp-server/.npmignore
@@ -1,0 +1,25 @@
+# Source files - only dist should be published
+src/
+
+# Test files
+*.test.ts
+*.spec.ts
+**/*.test.ts
+**/*.spec.ts
+
+# TypeScript configuration
+tsconfig.json
+tsconfig.*.json
+*.tsbuildinfo
+
+# Build and dev configuration
+vitest.config.ts
+*.config.js
+*.config.ts
+
+# Documentation (README.md is included via files array in package.json)
+docs/
+
+# Development files
+.eslintrc*
+.prettierrc*

--- a/packages/atxp-sqlite/.npmignore
+++ b/packages/atxp-sqlite/.npmignore
@@ -1,0 +1,25 @@
+# Source files - only dist should be published
+src/
+
+# Test files
+*.test.ts
+*.spec.ts
+**/*.test.ts
+**/*.spec.ts
+
+# TypeScript configuration
+tsconfig.json
+tsconfig.*.json
+*.tsbuildinfo
+
+# Build and dev configuration
+vitest.config.ts
+*.config.js
+*.config.ts
+
+# Documentation (README.md is included via files array in package.json)
+docs/
+
+# Development files
+.eslintrc*
+.prettierrc*


### PR DESCRIPTION
## Summary
- Add comprehensive .npmignore files to all 6 packages
- Exclude development files from npm publishing
- Reduce package sizes and prevent development file leakage

## Changes Made
- Created .npmignore files for: atxp-common, atxp-server, atxp-client, atxp-redis, atxp-sqlite, atxp-base
- Excluded: src/, test files, TypeScript configs, build configs, development files
- Only dist/ and essential files (README.md, package.json) are now published

## Testing
- Verified with `npm pack --dry-run` on all packages
- Confirmed only production files are included in package tarballs
- Package sizes remain appropriate with unnecessary files excluded

## Addresses
- ATXP-280: Create .npmignore files for each package
- Improves bundle hygiene and reduces npm registry noise

🤖 Generated with [Claude Code](https://claude.ai/code)