### PR TITLE
Add sideEffects: false to all package.json files (ATXP-279)

### DIFF
--- a/packages/atxp-base/package.json
+++ b/packages/atxp-base/package.json
@@ -9,6 +9,7 @@
     "directory": "packages/atxp-base"
   },
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/atxp-client/package.json
+++ b/packages/atxp-client/package.json
@@ -9,6 +9,7 @@
     "directory": "packages/atxp-client"
   },
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/atxp-common/package.json
+++ b/packages/atxp-common/package.json
@@ -9,6 +9,7 @@
     "directory": "packages/atxp-common"
   },
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/atxp-redis/package.json
+++ b/packages/atxp-redis/package.json
@@ -9,6 +9,7 @@
     "directory": "packages/atxp-redis"
   },
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/atxp-server/package.json
+++ b/packages/atxp-server/package.json
@@ -9,6 +9,7 @@
     "directory": "packages/atxp-server"
   },
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [

--- a/packages/atxp-sqlite/package.json
+++ b/packages/atxp-sqlite/package.json
@@ -9,6 +9,7 @@
     "directory": "packages/atxp-sqlite"
   },
   "type": "module",
+  "sideEffects": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "files": [


### PR DESCRIPTION
## Summary
- Add `sideEffects: false` declaration to all 6 packages  
- Enable better tree shaking optimization for consumers
- Follow modern npm package best practices

## Changes Made
- Added `"sideEffects": false` to all package.json files:
  - atxp-common, atxp-server, atxp-client, atxp-redis, atxp-sqlite, atxp-base
- Positioned consistently after `"type": "module"` in each file
- All JSON files validated for syntax correctness

## Benefits
- **Better tree shaking**: Bundlers can eliminate unused exports more aggressively
- **Smaller bundle sizes**: Dead code elimination is more effective
- **Improved performance**: Consumers get optimized builds automatically
- **Modern standards**: Follows current npm packaging best practices

## Technical Details
The `sideEffects: false` declaration tells bundlers like webpack, rollup, and esbuild that these packages are side-effect free, meaning:
- Importing a module doesn't execute code that affects global state
- Unused exports can be safely removed during bundling
- More aggressive optimizations are possible

## Testing
- Validated all JSON syntax with `python3 -m json.tool`
- Verified TypeScript compilation still works
- No breaking changes to existing functionality

## Addresses
- ATXP-279: Add sideEffects declaration to package.json
- Improves bundle optimization for SDK consumers

🤖 Generated with [Claude Code](https://claude.ai/code)