### PR TITLE
Implement dual package support (ESM/CJS) - ATXP-278

### DIFF
--- a/packages/atxp-base/package.json
+++ b/packages/atxp-base/package.json
@@ -10,7 +10,8 @@
   },
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js", 
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/atxp-client/package.json
+++ b/packages/atxp-client/package.json
@@ -10,7 +10,8 @@
   },
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js", 
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/atxp-common/package.json
+++ b/packages/atxp-common/package.json
@@ -10,7 +10,8 @@
   },
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js", 
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/atxp-redis/package.json
+++ b/packages/atxp-redis/package.json
@@ -10,7 +10,8 @@
   },
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js", 
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/atxp-server/package.json
+++ b/packages/atxp-server/package.json
@@ -10,7 +10,8 @@
   },
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js", 
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/packages/atxp-sqlite/package.json
+++ b/packages/atxp-sqlite/package.json
@@ -10,7 +10,8 @@
   },
   "type": "module",
   "sideEffects": false,
-  "main": "./dist/index.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js", 
   "types": "./dist/index.d.ts",
   "files": [
     "dist"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -81,7 +81,7 @@ const createConfig = (packageName, options = {}) => {
   }
 
   return [
-    // Individual file builds (preserves directory structure) 
+    // ESM build - individual file builds (preserves directory structure) 
     {
       input: 'src/index.ts',
       output: {
@@ -90,6 +90,29 @@ const createConfig = (packageName, options = {}) => {
         sourcemap: true,
         preserveModules: true,
         preserveModulesRoot: 'src'
+      },
+      external: isExternal,
+      plugins
+    },
+    // ESM entry point bundle
+    {
+      input: 'src/index.ts',
+      output: {
+        file: 'dist/index.js',
+        format: 'es',
+        sourcemap: true
+      },
+      external: isExternal,
+      plugins
+    },
+    // CommonJS entry point bundle
+    {
+      input: 'src/index.ts',
+      output: {
+        file: 'dist/index.cjs',
+        format: 'cjs',
+        sourcemap: true,
+        exports: 'named'
       },
       external: isExternal,
       plugins


### PR DESCRIPTION
## Summary

Implements dual package support for both ESM and CommonJS formats to improve compatibility with different module systems and build tools.

## Changes Made

**Rollup Configuration Updates:**
- Added ESM bundle generation: `dist/index.js`
- Added CommonJS bundle generation: `dist/index.cjs` 
- Maintained individual ESM files for optimal tree-shaking
- Preserved TypeScript declarations: `dist/index.d.ts`

**Package.json Updates:**
All packages now include proper dual package fields:
```json
{
  "main": "./dist/index.cjs",
  "module": "./dist/index.js", 
  "types": "./dist/index.d.ts"
}
```

**Format Verification:**
- **ESM bundles**: Use `import` statements and ES module syntax
- **CJS bundles**: Use `'use strict'` and `require()` statements
- **External dependencies**: Properly handled for both formats

## Bundle Generation

Each package now generates:
1. **Individual ESM files** (`dist/*.js`) - Preserves directory structure for tree-shaking
2. **ESM entry bundle** (`dist/index.js`) - Single ESM bundle for `module` field
3. **CJS entry bundle** (`dist/index.cjs`) - Single CommonJS bundle for `main` field  
4. **TypeScript declarations** (`dist/index.d.ts`) - Bundled type definitions

## Compatibility

**Module System Support:**
- ✅ Node.js CommonJS (`require()`)
- ✅ Node.js ESM (`import`)
- ✅ Webpack/Rollup bundlers (prefer ESM via `module` field)
- ✅ TypeScript projects (via `types` field)
- ✅ Tree-shaking optimization (via individual files)

**Build Tools:**
- ✅ Webpack: Uses `module` field for ESM, falls back to `main` for CJS
- ✅ Rollup: Prefers `module` field for optimal tree-shaking
- ✅ Vite: Uses `module` field for development, respects both in production
- ✅ Node.js: Uses `main` field for CommonJS imports

## Test Results

- [x] All packages build successfully with dual formats
- [x] Examples continue to work correctly (tested with basic example)
- [x] Generated bundles have correct format syntax
- [x] External dependencies properly handled in both formats
- [x] No breaking changes to existing consumers

## Example Usage

**ESM Import:**
```javascript
import { AtxpClient } from '@atxp/client'; // Uses dist/index.js
```

**CommonJS Require:**
```javascript
const { AtxpClient } = require('@atxp/client'); // Uses dist/index.cjs
```

**TypeScript:**
```typescript
import { AtxpClient } from '@atxp/client'; // Uses dist/index.d.ts for types
```

This resolves ATXP-278 and provides foundation for broader ecosystem compatibility.

🤖 Generated with [Claude Code](https://claude.ai/code)