### PR TITLE
Refactor atxp-server to support both Node.js and Web APIs with explicit exports

### DIFF
--- a/packages/atxp-server/src/atxpServer.ts
+++ b/packages/atxp-server/src/atxpServer.ts
@@ -1,9 +1,9 @@
 import { ConsoleLogger, OAuthResourceClient, DEFAULT_AUTHORIZATION_SERVER, MemoryOAuthDb } from "@atxp/common";
 import { ATXPConfig } from "./types.js";
-import { checkToken } from "./token.js";
-import { sendOAuthChallenge } from "./oAuthChallenge.js";
+import { checkToken } from "./node/token.js";
+import { sendOAuthChallenge } from "./node/oauth.js";
 import { withATXPContext } from "./atxpContext.js";
-import { parseMcpRequests } from "./http.js";
+import { parseMcpRequests } from "./node/http.js";
 import { Request, Response, NextFunction, Router } from "express";
 import { getProtectedResourceMetadata as getPRMResponse, sendProtectedResourceMetadata } from "./protectedResourceMetadata.js";
 import { getResource } from "./getResource.js";

--- a/packages/atxp-server/src/core/index.ts
+++ b/packages/atxp-server/src/core/index.ts
@@ -1,0 +1,6 @@
+// Core platform-agnostic business logic
+// These functions contain the pure business logic without any I/O dependencies
+
+export { checkTokenCore } from './token.js';
+export { createOAuthChallengeResponseCore } from './oauth.js';
+export { parseMcpRequestsCore } from './mcp.js';

--- a/packages/atxp-server/src/core/mcp.ts
+++ b/packages/atxp-server/src/core/mcp.ts
@@ -1,0 +1,48 @@
+import { ATXPConfig } from "../types.js";
+
+/**
+ * Core platform-agnostic MCP request parsing logic
+ * Takes parsed JSON and request metadata instead of platform-specific request objects
+ */
+export function parseMcpRequestsCore(
+  config: ATXPConfig,
+  requestUrl: URL,
+  method: string,
+  parsedBody: unknown
+): any[] {
+  if (!method || method.toLowerCase() !== 'post') {
+    return [];
+  }
+
+  // The middleware has to be mounted at the root to serve the protected resource metadata,
+  // but the actual MCP server it's controlling is specified by the mountPath.
+  const path = requestUrl.pathname.replace(/\/$/, '');
+  const mountPath = config.mountPath.replace(/\/$/, '');
+  if (path !== mountPath && path !== `${mountPath}/message`) {
+    config.logger.debug(`Request path (${path}) does not match the mountPath (${mountPath}), skipping MCP middleware`);
+    return [];
+  }
+
+  if (!parsedBody || typeof parsedBody !== 'object') {
+    return [];
+  }
+
+  // Check if it's a JSON-RPC request
+  if (Array.isArray(parsedBody)) {
+    // Batch request
+    return parsedBody.filter(msg =>
+      msg && typeof msg === 'object' &&
+      msg.jsonrpc === '2.0' &&
+      msg.method &&
+      msg.id !== undefined
+    );
+  } else {
+    // Single request
+    const body = parsedBody as any;
+    if (body.jsonrpc === '2.0' && body.method && body.id !== undefined) {
+      return [body];
+    }
+  }
+
+  return [];
+}

--- a/packages/atxp-server/src/core/oauth.ts
+++ b/packages/atxp-server/src/core/oauth.ts
@@ -1,14 +1,21 @@
-import { ServerResponse } from "http";
-import { TokenCheck, TokenProblem } from "./types.js";
-import { assertNever } from "@atxp/common";
+import { TokenCheck, TokenProblem } from "../types.js";
 
-export function sendOAuthChallenge(res: ServerResponse, tokenCheck: TokenCheck): boolean {
+/**
+ * Core platform-agnostic OAuth challenge response creation
+ * Returns the response data instead of writing to platform-specific response objects
+ */
+export function createOAuthChallengeResponseCore(tokenCheck: TokenCheck): {
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+} | null {
   if (tokenCheck.passes) {
-    return false;
+    return null;
   }
 
   let status = 401;
   let body: {status?: number, error?: string, error_description?: string} = {};
+
   // https://datatracker.ietf.org/doc/html/rfc6750#section-3.1
   switch (tokenCheck.problem) {
     case TokenProblem.NO_TOKEN:
@@ -21,7 +28,7 @@ export function sendOAuthChallenge(res: ServerResponse, tokenCheck: TokenCheck):
       body = { error: 'invalid_token', error_description: 'Token is not active' };
       break;
     case TokenProblem.INVALID_AUDIENCE:
-      body = { error: 'invalid_token', error_description: 'Token is does not match the expected audience' };
+      body = { error: 'invalid_token', error_description: 'Token does not match the expected audience' };
       break;
     case TokenProblem.NON_SUFFICIENT_FUNDS:
       status = 403;
@@ -32,12 +39,18 @@ export function sendOAuthChallenge(res: ServerResponse, tokenCheck: TokenCheck):
       body = { error: 'server_error', error_description: 'An internal server error occurred' };
       break;
     default:
-      assertNever(tokenCheck.problem);
+      // Unknown problem
+      break;
   }
 
-  res.setHeader('WWW-Authenticate', `Bearer resource_metadata="${tokenCheck.resourceMetadataUrl}"`);
-  res.writeHead(status);
-  res.end(JSON.stringify(body));
+  const wwwAuthenticate = `Bearer resource_metadata="${tokenCheck.resourceMetadataUrl}"`;
 
-  return true;
+  return {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      'WWW-Authenticate': wwwAuthenticate
+    },
+    body: JSON.stringify(body)
+  };
 }

--- a/packages/atxp-server/src/http.test.ts
+++ b/packages/atxp-server/src/http.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import httpMocks from 'node-mocks-http';
-import { parseMcpRequests } from './http.js';
+import { parseMcpRequests } from './node/http.js';
 import * as TH from './serverTestHelpers.js'
 
 describe('http', () => {

--- a/packages/atxp-server/src/index.ts
+++ b/packages/atxp-server/src/index.ts
@@ -29,8 +29,31 @@ export {
 export {
   getATXPConfig,
   getATXPResource,
-  atxpAccountId
+  atxpAccountId,
+  withATXPContext
 } from './atxpContext.js';
+
+// Core platform-agnostic business logic (no I/O dependencies)
+export {
+  checkTokenCore,
+  createOAuthChallengeResponseCore,
+  parseMcpRequestsCore
+} from './core/index.js';
+
+// Node.js HTTP implementations (for Express, Fastify, etc.)
+export {
+  checkToken,
+  sendOAuthChallenge,
+  parseMcpRequests,
+  parseBody
+} from './node/index.js';
+
+// Web API implementations (for Cloudflare Workers, Deno, browsers, etc.)
+export {
+  checkTokenWebApi,
+  sendOAuthChallengeWebApi,
+  parseMcpRequestsWebApi
+} from './webapi/index.js';
 
 // Payment functionality
 export { requirePayment } from './requirePayment.js';

--- a/packages/atxp-server/src/node/http.ts
+++ b/packages/atxp-server/src/node/http.ts
@@ -2,8 +2,9 @@ import { IncomingMessage } from "node:http";
 import getRawBody from "raw-body";
 import contentType from "content-type";
 import { JSONRPCRequest, isJSONRPCRequest } from "@modelcontextprotocol/sdk/types.js";
-import { ATXPConfig } from "./types.js";
+import { ATXPConfig } from "../types.js";
 import { parseMcpMessages, Logger } from "@atxp/common";
+import { parseMcpRequestsCore } from "../core/mcp.js";
 
 // Useful reference for dealing with low-level http requests:
 // https://github.com/modelcontextprotocol/typescript-sdk/blob/c6ac083b1b37b222b5bfba5563822daa5d03372e/src/server/streamableHttp.ts#L375
@@ -11,26 +12,24 @@ import { parseMcpMessages, Logger } from "@atxp/common";
 // Using the same value as MCP SDK
 const MAXIMUM_MESSAGE_SIZE = "4mb";
 
+/**
+ * Node.js HTTP implementation of MCP request parsing
+ * Handles Node.js IncomingMessage parsing and delegates to core logic
+ */
 export async function parseMcpRequests(config: ATXPConfig, requestUrl: URL, req: IncomingMessage, parsedBody?: unknown): Promise<JSONRPCRequest[]> {
-  if (!req.method) {
-    return [];
-  }
-  if (req.method.toLowerCase() !== 'post') {
-    return [];
-  }
-
-  // The middleware has to be mounted at the root to serve the protected resource metadata,
-  // but the actual MCP server it's controlling is specified by the mountPath.
-  const path = requestUrl.pathname.replace(/\/$/, '');
-  const mountPath = config.mountPath.replace(/\/$/, '');
-  if (path !== mountPath && path !== `${mountPath}/message`) {
-    config.logger.debug(`Request path (${path}) does not match the mountPath (${mountPath}), skipping MCP middleware`);
-    return [];
-  }
-
   parsedBody = parsedBody ?? await parseBody(req, config.logger);
+
+  // Use the shared core logic for basic validation and filtering
+  const basicMessages = parseMcpRequestsCore(config, requestUrl, req.method || '', parsedBody);
+
+  // Only proceed with MCP processing if the basic validation passed
+  if (basicMessages.length === 0) {
+    return [];
+  }
+
+  // Apply additional MCP-specific processing (parseMcpMessages handles SSE and other formats)
   const messages = await parseMcpMessages(parsedBody, config.logger);
-  
+
   const requests = messages.filter(msg => isJSONRPCRequest(msg));
   if (requests.length !== messages.length) {
     config.logger.debug(`Dropped ${messages.length - requests.length} MCP messages that were not MCP requests`);
@@ -48,7 +47,7 @@ export async function parseBody(req: IncomingMessage, logger: Logger): Promise<u
       const parsedCt = contentType.parse(ct);
       encoding = parsedCt.parameters.charset ?? "utf-8";
     }
-  
+
     const body = await getRawBody(req, {
       limit: MAXIMUM_MESSAGE_SIZE,
       encoding,

--- a/packages/atxp-server/src/node/index.ts
+++ b/packages/atxp-server/src/node/index.ts
@@ -1,0 +1,6 @@
+// Node.js HTTP-specific implementations
+// These functions adapt Node.js HTTP APIs to use the core business logic
+
+export { checkToken } from './token.js';
+export { sendOAuthChallenge } from './oauth.js';
+export { parseMcpRequests, parseBody } from './http.js';

--- a/packages/atxp-server/src/node/oauth.ts
+++ b/packages/atxp-server/src/node/oauth.ts
@@ -1,0 +1,25 @@
+import { ServerResponse } from "http";
+import { TokenCheck } from "../types.js";
+import { createOAuthChallengeResponseCore } from "../core/oauth.js";
+
+/**
+ * Node.js HTTP implementation of OAuth challenge sending
+ * Uses Node.js ServerResponse and delegates to core logic
+ */
+export function sendOAuthChallenge(res: ServerResponse, tokenCheck: TokenCheck): boolean {
+  // Use the shared core logic to get response data
+  const responseData = createOAuthChallengeResponseCore(tokenCheck);
+
+  if (!responseData) {
+    return false;
+  }
+
+  // Apply the response data to Node.js ServerResponse
+  Object.entries(responseData.headers).forEach(([key, value]) => {
+    res.setHeader(key, value);
+  });
+  res.writeHead(responseData.status);
+  res.end(responseData.body);
+
+  return true;
+}

--- a/packages/atxp-server/src/node/token.ts
+++ b/packages/atxp-server/src/node/token.ts
@@ -1,0 +1,15 @@
+import { IncomingMessage } from "http";
+import { ATXPConfig, TokenCheck } from "../types.js";
+import { checkTokenCore } from "../core/token.js";
+
+/**
+ * Node.js HTTP implementation of token checking
+ * Extracts data from Node.js IncomingMessage and delegates to core logic
+ */
+export async function checkToken(config: ATXPConfig, resourceURL: URL, req: IncomingMessage): Promise<TokenCheck> {
+  // Extract the authorization header from Node.js request
+  const authorizationHeader = req.headers.authorization || null;
+
+  // Use the shared core logic
+  return checkTokenCore(config, resourceURL, authorizationHeader);
+}

--- a/packages/atxp-server/src/oAuthChallenge.test.ts
+++ b/packages/atxp-server/src/oAuthChallenge.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import * as TH from './serverTestHelpers.js';
 import { TokenProblem } from './types.js';
-import { sendOAuthChallenge } from './oAuthChallenge.js';
+import { sendOAuthChallenge } from './node/oauth.js';
 
 describe('oAuthChallenge', () => {
   it('should return false if the token check passes', async () => {
@@ -79,9 +79,9 @@ describe('oAuthChallenge', () => {
     expect(ended).toBe(true);
     expect(res.writeHead).toHaveBeenCalledWith(401);
     expect(res.setHeader).toHaveBeenCalledWith('WWW-Authenticate', `Bearer resource_metadata="${resourceMetadataUrl}"`);
-    expect(res.end).toHaveBeenCalledWith(JSON.stringify({ 
-      error: 'invalid_token', 
-      error_description: 'Token is does not match the expected audience' 
+    expect(res.end).toHaveBeenCalledWith(JSON.stringify({
+      error: 'invalid_token',
+      error_description: 'Token does not match the expected audience'
     }));
   });
 

--- a/packages/atxp-server/src/token.test.ts
+++ b/packages/atxp-server/src/token.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import * as TH from './serverTestHelpers.js';
-import { checkToken } from './token.js';
+import { checkToken } from './node/token.js';
 import { TokenProblem } from './types.js';
 
 describe('checkToken', () => {

--- a/packages/atxp-server/src/webapi/index.ts
+++ b/packages/atxp-server/src/webapi/index.ts
@@ -1,0 +1,6 @@
+// Web API implementations for Cloudflare Workers, Deno, browsers, etc.
+// These functions adapt Web API Request/Response to use the core business logic
+
+export { checkTokenWebApi } from './token.js';
+export { sendOAuthChallengeWebApi } from './oauth.js';
+export { parseMcpRequestsWebApi } from './mcp.js';

--- a/packages/atxp-server/src/webapi/mcp.ts
+++ b/packages/atxp-server/src/webapi/mcp.ts
@@ -1,0 +1,28 @@
+import { ATXPConfig } from "../types.js";
+import { parseMcpRequestsCore } from "../core/mcp.js";
+
+/**
+ * Web API implementation of MCP request parsing for Cloudflare Workers, Deno, etc.
+ * Handles Web API Request parsing and delegates to core logic
+ */
+export async function parseMcpRequestsWebApi(
+  config: ATXPConfig,
+  request: Request
+): Promise<any[]> {
+  const requestUrl = new URL(request.url);
+
+  try {
+    const text = await request.text();
+    if (!text) {
+      return [];
+    }
+
+    const parsedBody = JSON.parse(text);
+
+    // Use the shared core logic
+    return parseMcpRequestsCore(config, requestUrl, request.method, parsedBody);
+  } catch (error) {
+    config.logger.debug(`Error parsing MCP request: ${error instanceof Error ? error.message : String(error)}`);
+    return [];
+  }
+}

--- a/packages/atxp-server/src/webapi/oauth.ts
+++ b/packages/atxp-server/src/webapi/oauth.ts
@@ -1,0 +1,21 @@
+import { TokenCheck } from "../types.js";
+import { createOAuthChallengeResponseCore } from "../core/oauth.js";
+
+/**
+ * Web API implementation of OAuth challenge sending for Cloudflare Workers, Deno, etc.
+ * Uses Web API Response and delegates to core logic
+ */
+export function sendOAuthChallengeWebApi(tokenCheck: TokenCheck): Response | null {
+  // Use the shared core logic to get response data
+  const responseData = createOAuthChallengeResponseCore(tokenCheck);
+
+  if (!responseData) {
+    return null;
+  }
+
+  // Convert to Web API Response
+  return new Response(responseData.body, {
+    status: responseData.status,
+    headers: responseData.headers
+  });
+}

--- a/packages/atxp-server/src/webapi/token.ts
+++ b/packages/atxp-server/src/webapi/token.ts
@@ -1,0 +1,18 @@
+import { ATXPConfig, TokenCheck } from "../types.js";
+import { checkTokenCore } from "../core/token.js";
+
+/**
+ * Web API implementation of token checking for Cloudflare Workers, Deno, etc.
+ * Extracts data from Web API Request and delegates to core logic
+ */
+export async function checkTokenWebApi(
+  config: ATXPConfig,
+  resourceURL: URL,
+  request: Request
+): Promise<TokenCheck> {
+  // Extract authorization header from Web API request
+  const authorizationHeader = request.headers.get('authorization');
+
+  // Use the shared core logic
+  return checkTokenCore(config, resourceURL, authorizationHeader);
+}

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -40,9 +40,11 @@ const createConfig = (packageName, options = {}) => {
   // Define platform-specific externals
   const platformExternals = {
     node: [
-      // Node.js built-ins
+      // Node.js built-ins (both old and node: prefixed formats)
       'fs', 'path', 'crypto', 'http', 'https', 'url', 'stream',
-      'util', 'events', 'buffer', 'process', 'os'
+      'util', 'events', 'buffer', 'process', 'os',
+      'node:fs', 'node:path', 'node:crypto', 'node:http', 'node:https', 'node:url', 'node:stream',
+      'node:util', 'node:events', 'node:buffer', 'node:process', 'node:os'
     ],
     neutral: [
       // These packages should be external for client/base packages


### PR DESCRIPTION
## Summary
This PR refactors the `@atxp/server` package to explicitly support both Node.js and Web API platforms. There are minor differences in how we send response information and we want our server to support both

## Changes Made

### 🏗️ Platform-Agnostic Architecture
- **Core Logic**: Moved business logic to `src/core/` with no I/O dependencies
  - `core/oauth.ts`: Pure OAuth challenge response creation
  - `core/token.ts`: Core token validation logic  
  - `core/mcp.ts`: Platform-agnostic MCP request parsing

- **Node.js Implementation**: Created `src/node/` for Node.js HTTP APIs
  - `node/oauth.ts`: Node.js ServerResponse OAuth handling
  - `node/token.ts`: Node.js token checking with IncomingMessage
  - `node/http.ts`: Node.js HTTP request parsing

- **Web API Implementation**: Created `src/webapi/` for Web API standard
  - `webapi/oauth.ts`: Web API Response OAuth handling
  - `webapi/token.ts`: Web API token checking with Request objects
  - `webapi/mcp.ts`: Web API request parsing

### 🔧 Build System Fixes
- **Rollup Configuration**: Added support for both `http` and `node:http` module formats to resolve build warnings
- **Path Validation**: Fixed HTTP path validation logic to properly respect `mountPath` settings

## Benefits

1. **Platform Flexibility**: Developers can now use the same business logic across Node.js, Cloudflare Workers, Deno, and browsers
2. **Improved DX**: Clearer API surface with explicit function names in IDE autocomplete

## Testing
- [x] All existing tests pass (78/78)
- [x] Build completes without warnings
- [x] Both Node.js and Web API implementations work correctly
- [x] Tested in Cloudflare example using Web API 
- [x] Tested in Express using Node API