### PR TITLE
Break out constants file to fix circular dependency

### DIFF
--- a/packages/atxp-client/src/baseAccount.ts
+++ b/packages/atxp-client/src/baseAccount.ts
@@ -4,8 +4,6 @@ import { BasePaymentMaker } from './basePaymentMaker.js';
 import { createWalletClient, http } from 'viem';
 import { base } from 'viem/chains';
 
-export const USDC_CONTRACT_ADDRESS_BASE = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"; // USDC on Base mainnet
-
 export class BaseAccount implements Account {
   accountId: string;
   paymentMakers: { [key: string]: PaymentMaker };

--- a/packages/atxp-client/src/baseConstants.ts
+++ b/packages/atxp-client/src/baseConstants.ts
@@ -1,0 +1,1 @@
+export const USDC_CONTRACT_ADDRESS_BASE = "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913"; // USDC on Base mainnet

--- a/packages/atxp-client/src/basePaymentMaker.insufficientFunds.test.ts
+++ b/packages/atxp-client/src/basePaymentMaker.insufficientFunds.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { BasePaymentMaker } from './basePaymentMaker.js';
 import { InsufficientFundsError, PaymentNetworkError } from './types.js';
 import { BigNumber } from 'bignumber.js';
-import { USDC_CONTRACT_ADDRESS_BASE } from './baseAccount.js';
+import { USDC_CONTRACT_ADDRESS_BASE } from './baseConstants.js';
 
 // Mock viem functions
 vi.mock('viem', () => ({

--- a/packages/atxp-client/src/basePaymentMaker.ts
+++ b/packages/atxp-client/src/basePaymentMaker.ts
@@ -12,7 +12,7 @@ import {
 } from "viem";
 import { base } from "viem/chains";
 import { BigNumber } from "bignumber.js";
-import { USDC_CONTRACT_ADDRESS_BASE } from './baseAccount.js';
+import { USDC_CONTRACT_ADDRESS_BASE } from './baseConstants.js';
 
 // Type for the extended wallet client with public actions
 type ExtendedWalletClient = WalletClient & PublicActions;

--- a/packages/atxp-client/src/index.ts
+++ b/packages/atxp-client/src/index.ts
@@ -41,7 +41,10 @@ export {
 } from './atxpAccount.js';
 
 export {
-  USDC_CONTRACT_ADDRESS_BASE,
+  USDC_CONTRACT_ADDRESS_BASE
+} from './baseConstants.js';
+
+export {
   BaseAccount
 } from './baseAccount.js';
 


### PR DESCRIPTION
We were getting a circular dependency between `baseAccount.ts` and `basePaymentMaker.ts` due to this constant. I broke it out into its own file to fix this.