### PR TITLE
Pass paymentRequestId to ATXP /pay

### DIFF
--- a/packages/atxp-client/src/atxpAccount.ts
+++ b/packages/atxp-client/src/atxpAccount.ts
@@ -33,7 +33,7 @@ class ATXPHttpPaymentMaker implements PaymentMaker {
     this.fetchFn = fetchFn;
   }
 
-  async makePayment(amount: BigNumber, currency: Currency, receiver: string, memo: string): Promise<string> {
+  async makePayment(amount: BigNumber, currency: Currency, receiver: string, memo: string, paymentRequestId?: string): Promise<string> {
     // Make a regular payment via the /pay endpoint
     const response = await this.fetchFn(`${this.origin}/pay`, {
       method: 'POST',
@@ -46,6 +46,7 @@ class ATXPHttpPaymentMaker implements PaymentMaker {
         currency,
         receiver,
         memo,
+        ...(paymentRequestId && { paymentRequestId })
       }),
     });
 

--- a/packages/atxp-client/src/atxpFetcher.ts
+++ b/packages/atxp-client/src/atxpFetcher.ts
@@ -160,7 +160,7 @@ export class ATXPFetcher {
 
       let paymentId: string;
       try {
-        paymentId = await paymentMaker.makePayment(amount, dest.currency, dest.address, paymentRequestData.iss);
+        paymentId = await paymentMaker.makePayment(amount, dest.currency, dest.address, paymentRequestData.iss, paymentRequestId);
         this.logger.info(`ATXP: made payment of ${amount.toString()} ${dest.currency} on ${dest.network}: ${paymentId}`);
         await this.onPayment({ payment: prospectivePayment });
 
@@ -279,7 +279,7 @@ export class ATXPFetcher {
 
     let paymentId: string;
     try {
-      paymentId = await paymentMaker.makePayment(amount, currency, destination, paymentRequestData.iss);
+      paymentId = await paymentMaker.makePayment(amount, currency, destination, paymentRequestData.iss, paymentRequestId);
       this.logger.info(`ATXP: made payment of ${amount} ${currency} on ${requestedNetwork}: ${paymentId}`);
       
       // Call onPayment callback after successful payment

--- a/packages/atxp-client/src/basePaymentMaker.ts
+++ b/packages/atxp-client/src/basePaymentMaker.ts
@@ -116,7 +116,7 @@ export class BasePaymentMaker implements PaymentMaker {
     return jwt;
   }
 
-  async makePayment(amount: BigNumber, currency: Currency, receiver: string): Promise<string> {
+  async makePayment(amount: BigNumber, currency: Currency, receiver: string, memo: string, paymentRequestId?: string): Promise<string> {
     if (currency.toUpperCase() !== 'USDC') {
       throw new PaymentNetworkErrorClass('Only USDC currency is supported; received ' + currency);
     }

--- a/packages/atxp-client/src/solanaPaymentMaker.ts
+++ b/packages/atxp-client/src/solanaPaymentMaker.ts
@@ -49,7 +49,7 @@ export class SolanaPaymentMaker implements PaymentMaker {
     return generateJWT(this.source.publicKey.toBase58(), privateKey, paymentRequestId || '', codeChallenge || '');
   }
 
-  makePayment = async (amount: BigNumber, currency: Currency, receiver: string, memo: string): Promise<string> => {
+  makePayment = async (amount: BigNumber, currency: Currency, receiver: string, memo: string, paymentRequestId?: string): Promise<string> => {
     if (currency.toUpperCase() !== 'USDC') {
       throw new PaymentNetworkError('Only USDC currency is supported; received ' + currency);
     }

--- a/packages/atxp-client/src/types.ts
+++ b/packages/atxp-client/src/types.ts
@@ -77,6 +77,6 @@ export class PaymentNetworkError extends Error {
 }
 
 export interface PaymentMaker {
-  makePayment: (amount: BigNumber, currency: Currency, receiver: string, memo: string) => Promise<string>;
+  makePayment: (amount: BigNumber, currency: Currency, receiver: string, memo: string, paymentRequestId?: string) => Promise<string>;
   generateJWT: (params: {paymentRequestId: string, codeChallenge: string}) => Promise<string>;
 }


### PR DESCRIPTION
Combined with https://github.com/circuitandchisel/accounts/pull/54, ensures that ATXPAccount's calls to `/pay` are idempotent, preventing transaction failures due to race conditions.

This parameter is potentially useful to other implementations as well - it's now a parameter in the `PaymentMaker` interface.