### PR TITLE
[ATXP-322] Add in world to list of Networks

### DIFF
--- a/packages/atxp-common/src/types.ts
+++ b/packages/atxp-common/src/types.ts
@@ -20,7 +20,7 @@ export type UrlString = `http://${string}` | `https://${string}`;
 export type AuthorizationServerUrl = UrlString;
 
 export type Currency = 'USDC';
-export type Network = 'solana' | 'base';
+export type Network = 'solana' | 'base' | 'world';
 
 export type PaymentRequestDestination = {
   network: Network;

--- a/packages/atxp-server/src/paymentDestination.ts
+++ b/packages/atxp-server/src/paymentDestination.ts
@@ -175,10 +175,9 @@ export class ATXPPaymentDestination implements PaymentDestination {
           network = 'base'; // Base is an Ethereum L2
           break;
         case 'base':
-          network = 'base'; // Already correct
-          break;
+        case 'world':
         case 'solana':
-          network = 'solana';
+          network = networkFromItem
           break;
         default:
           this.logger.warn(`Unknown network: ${networkFromItem}, skipping`);


### PR DESCRIPTION
# Description
Adds `world` into the list of supported networks

# Motivation
https://linear.app/circuitandchisel/issue/ATXP-322/add-world-to-the-network-list-used-in-atxp-devsdk

# Test
No regressions