### PR TITLE
Batch payment example, implementation, and tests

### DIFF
--- a/examples/batch-payments/README.md
+++ b/examples/batch-payments/README.md
@@ -1,0 +1,57 @@
+# Batch Payments Example
+
+MCP server demonstrating batch payment processing.
+
+## Features
+
+- Simple greeting tool with batch payment
+- Middleware expects $0.05 total payment
+- Tool requires $0.01 per batch
+
+## Setup
+
+1. Install dependencies:
+```bash
+npm install
+```
+
+2. Configure environment variables:
+```bash
+cp env.example .env
+```
+
+Edit `.env` with your ATXP connection string.
+
+3. Run the server:
+```bash
+npm run dev
+```
+
+## Tool
+
+### `batch_payment`
+
+A personalized greeting that requires batch payment.
+
+**Parameters:**
+- `message`: (optional) Custom message to include in greeting
+
+**Example:**
+```json
+{
+  "message": "Thanks for using the batch payment system!"
+}
+```
+
+## Payment Configuration
+
+- Middleware expects: $0.05 total payment
+- Tool requires: $0.01 per batch
+
+## Running
+
+```bash
+npm run dev   # development
+npm run build # build
+npm start     # production
+```

--- a/examples/batch-payments/README.md
+++ b/examples/batch-payments/README.md
@@ -10,22 +10,27 @@ MCP server demonstrating batch payment processing.
 
 ## Setup
 
-1. Install dependencies:
+This example is part of the ATXP SDK monorepo and should be run from the SDK root directory.
+
+1. From the SDK root directory, install all dependencies:
 ```bash
 npm install
 ```
 
 2. Configure environment variables:
 ```bash
+cd examples/batch-payments
 cp env.example .env
 ```
 
 Edit `.env` with your ATXP connection string.
 
-3. Run the server:
+3. Run the server (from the examples/batch-payments directory):
 ```bash
 npm run dev
 ```
+
+Note: The dev script will automatically build the SDK packages before starting the server.
 
 ## Tool
 

--- a/examples/batch-payments/README.md
+++ b/examples/batch-payments/README.md
@@ -5,8 +5,9 @@ MCP server demonstrating batch payment processing.
 ## Features
 
 - Simple greeting tool with batch payment
-- Middleware expects $0.05 total payment
-- Tool requires $0.01 per batch
+- Middleware request $0.05 per payment
+- Tool requires $0.01 per call
+- Payments are triggered every 5 tool calls
 
 ## Setup
 
@@ -51,7 +52,7 @@ A personalized greeting that requires batch payment.
 ## Payment Configuration
 
 - Middleware expects: $0.05 total payment
-- Tool requires: $0.01 per batch
+- Tool requires: $0.01 per call
 
 ## Running
 

--- a/examples/batch-payments/dev.sh
+++ b/examples/batch-payments/dev.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Build the main library first
+cd ../.. && npm run build
+
+# Go back to examples directory and run the development server
+cd examples/batch-payments && npx tsx src/index.ts "$@" 

--- a/examples/batch-payments/env.example
+++ b/examples/batch-payments/env.example
@@ -1,0 +1,8 @@
+# Server port (optional, defaults to 3011)
+PORT=3011
+
+# Environment (development enables HTTP)
+NODE_ENV=development
+
+# ATXP connection string (required)
+ATXP_CONNECTION_STRING=https://accounts.atxp.ai/?connection_token=your_connection_token_here

--- a/examples/batch-payments/package.json
+++ b/examples/batch-payments/package.json
@@ -1,28 +1,28 @@
 {
-  "name": "@atxp/batch-payments-example",
+  "name": "atxp-batch-payments-example",
   "version": "1.0.0",
-  "private": true,
+  "description": "Example MCP server demonstrating batch payment processing",
+  "main": "src/index.ts",
   "type": "module",
-  "main": "dist/index.js",
   "scripts": {
-    "dev": "tsx src/index.ts",
+    "prebuild": "cd ../.. && npm run build",
     "build": "tsc",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "dev": "./dev.sh",
+    "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@atxp/common": "workspace:*",
-    "@atxp/express": "workspace:*",
-    "@atxp/server": "workspace:*",
-    "@modelcontextprotocol/sdk": "^1.0.4",
+    "@atxp/express": "*",
+    "@modelcontextprotocol/sdk": "^1.15.0",
+    "express": "^5.0.1",
+    "zod": "^3.24.1",
     "bignumber.js": "^9.1.2",
-    "dotenv": "^16.4.5",
-    "express": "^5.0.0",
-    "zod": "^3.22.4"
+    "dotenv": "^17.2.1"
   },
   "devDependencies": {
-    "@types/express": "^5.0.0",
-    "@types/node": "^20.14.10",
-    "tsx": "^4.7.1",
-    "typescript": "^5.5.3"
+    "@types/express": "^5.0.1",
+    "@types/node": "^22.13.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.3"
   }
 }

--- a/examples/batch-payments/package.json
+++ b/examples/batch-payments/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@atxp/batch-payments-example",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "dev": "tsx src/index.ts",
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@atxp/common": "workspace:*",
+    "@atxp/express": "workspace:*",
+    "@atxp/server": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.0.4",
+    "bignumber.js": "^9.1.2",
+    "dotenv": "^16.4.5",
+    "express": "^5.0.0",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.0",
+    "@types/node": "^20.14.10",
+    "tsx": "^4.7.1",
+    "typescript": "^5.5.3"
+  }
+}

--- a/examples/batch-payments/src/index.ts
+++ b/examples/batch-payments/src/index.ts
@@ -6,8 +6,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { z } from 'zod';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { BigNumber } from 'bignumber.js';
-import { atxpExpress, requirePayment, getUserId } from '@atxp/express';
-import { ATXPPaymentDestination } from '@atxp/server';
+import { atxpExpress, requirePayment, getUserId, ATXPPaymentDestination } from '@atxp/express';
 
 const PORT = process.env.PORT ? parseInt(process.env.PORT) : 3011;
 

--- a/examples/batch-payments/src/index.ts
+++ b/examples/batch-payments/src/index.ts
@@ -6,7 +6,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { z } from 'zod';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { BigNumber } from 'bignumber.js';
-import { atxpExpress, requirePayment, getUserId, ATXPPaymentDestination } from '@atxp/express';
+import { atxpExpress, requirePayment, atxpAccountId, ATXPPaymentDestination } from '@atxp/express';
 
 const PORT = process.env.PORT ? parseInt(process.env.PORT) : 3011;
 
@@ -28,7 +28,7 @@ async function main() {
       message: z.string().optional().describe('Optional custom message'),
     },
     async ({ message }: { message?: string }): Promise<CallToolResult> => {
-      const userId = getUserId();
+      const userId = atxpAccountId();
 
       console.log('💰 Requiring payment of $0.01...');
       await requirePayment({ price: BigNumber(0.01) });

--- a/examples/batch-payments/src/index.ts
+++ b/examples/batch-payments/src/index.ts
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+import 'dotenv/config';
+import express, { Request, Response } from 'express';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { z } from 'zod';
+import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { BigNumber } from 'bignumber.js';
+import { atxpExpress, requirePayment, getUserId } from '@atxp/express';
+import { ATXPPaymentDestination } from '@atxp/server';
+
+const PORT = process.env.PORT ? parseInt(process.env.PORT) : 3011;
+
+async function main() {
+  const server = new McpServer({
+    name: 'batch-payments-example',
+    version: '1.0.0',
+  }, {
+    capabilities: {
+      logging: {},
+      tools: {}
+    }
+  });
+
+  server.tool(
+    'batch_payment',
+    'A personalized greeting that requires batch payment',
+    {
+      message: z.string().optional().describe('Optional custom message'),
+    },
+    async ({ message }: { message?: string }): Promise<CallToolResult> => {
+      const userId = getUserId();
+
+      console.log('💰 Requiring payment of $0.01...');
+      await requirePayment({ price: BigNumber(0.01) });
+
+      console.log(`✅ Payment confirmed for user ${userId}`);
+
+      const greeting = `Hello ${userId}! Your batch payment was processed successfully.${message ? ` ${message}` : ''}`;
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: greeting,
+          }
+        ],
+      };
+    }
+  );
+
+  const app = express();
+  app.use(express.json());
+
+  const paymentDestination = new ATXPPaymentDestination(process.env.ATXP_CONNECTION_STRING!);
+
+  const atxpRouter = atxpExpress({
+    paymentDestination,
+    payeeName: 'Batch Payments Example',
+    allowHttp: process.env.NODE_ENV === 'development',
+    minimumPayment: BigNumber(0.05)
+  });
+
+  app.use(atxpRouter as any);
+
+  app.post('/', async (req: Request, res: Response) => {
+    console.log('📨 Received MCP request');
+
+    try {
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableJsonResponse: true
+      });
+
+      await server.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+
+      res.on('close', () => {
+        console.log('🔌 Request connection closed');
+        transport.close();
+        server.close();
+      });
+    } catch (error) {
+      console.error('❌ Error handling MCP request:', error);
+      if (!res.headersSent) {
+        res.status(500).json({
+          jsonrpc: '2.0',
+          error: {
+            code: -32603,
+            message: 'Internal server error',
+          },
+          id: null,
+        });
+      }
+    }
+  });
+
+  // Health check endpoint
+  app.get('/health', (req: Request, res: Response) => {
+    res.json({
+      status: 'healthy',
+      service: 'batch-payments-example',
+      version: '1.0.0',
+      timestamp: new Date().toISOString()
+    });
+  });
+
+  // Handle unsupported methods
+  ['get', 'put', 'delete', 'patch'].forEach(method => {
+    (app as any)[method]('/', (req: Request, res: Response) => {
+      console.log(`❌ Received unsupported ${method.toUpperCase()} request`);
+      res.status(405).json({
+        jsonrpc: "2.0",
+        error: {
+          code: -32000,
+          message: "Method not allowed. Use POST for MCP requests."
+        },
+        id: null
+      });
+    });
+  });
+
+  const httpServer = app.listen(PORT, () => {
+    console.log(`🎉 Batch Payments Example listening on port ${PORT}`);
+    console.log(`📍 Server URL: http://localhost:${PORT}`);
+    console.log(`🏥 Health check: http://localhost:${PORT}/health`);
+    console.log('');
+    console.log('Configuration:');
+    console.log('  💵 Middleware expects: $0.05 total payment');
+    console.log('  🔧 Tool requires: $0.01 per batch');
+    console.log('');
+    console.log('Available tools:');
+    console.log('  📋 batch_payment - Process batch payments with user tracking');
+    console.log('');
+    console.log('Ready to receive MCP requests with ATXP authentication and payments! 💫');
+  });
+
+  // Graceful shutdown
+  process.on('SIGINT', () => {
+    console.log('\n🛑 Shutting down server...');
+    httpServer.close(() => {
+      console.log('✅ Server stopped gracefully');
+      process.exit(0);
+    });
+  });
+
+  process.on('SIGTERM', () => {
+    console.log('\n🛑 Received SIGTERM, shutting down server...');
+    httpServer.close(() => {
+      console.log('✅ Server stopped gracefully');
+      process.exit(0);
+    });
+  });
+}
+
+// Handle unhandled errors
+process.on('unhandledRejection', (reason, promise) => {
+  console.error('❌ Unhandled Rejection at:', promise, 'reason:', reason);
+  process.exit(1);
+});
+
+process.on('uncaughtException', (error) => {
+  console.error('❌ Uncaught Exception:', error);
+  process.exit(1);
+});
+
+main().catch((error) => {
+  console.error('❌ Failed to start server:', error);
+  process.exit(1);
+});

--- a/examples/batch-payments/tsconfig.json
+++ b/examples/batch-payments/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "node",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6011,6 +6011,7 @@
     },
     "node_modules/@solana/buffer-layout": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "~6.0.3"
@@ -6021,6 +6022,7 @@
     },
     "node_modules/@solana/buffer-layout-utils": {
       "version": "0.2.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
@@ -6034,6 +6036,7 @@
     },
     "node_modules/@solana/codecs": {
       "version": "2.0.0-rc.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0-rc.1",
@@ -6048,6 +6051,7 @@
     },
     "node_modules/@solana/codecs-core": {
       "version": "2.0.0-rc.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0-rc.1"
@@ -6058,6 +6062,7 @@
     },
     "node_modules/@solana/codecs-data-structures": {
       "version": "2.0.0-rc.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0-rc.1",
@@ -6070,6 +6075,7 @@
     },
     "node_modules/@solana/codecs-numbers": {
       "version": "2.0.0-rc.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0-rc.1",
@@ -6081,6 +6087,7 @@
     },
     "node_modules/@solana/codecs-strings": {
       "version": "2.0.0-rc.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0-rc.1",
@@ -6094,6 +6101,7 @@
     },
     "node_modules/@solana/errors": {
       "version": "2.0.0-rc.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
@@ -6108,6 +6116,7 @@
     },
     "node_modules/@solana/errors/node_modules/chalk": {
       "version": "5.6.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -6459,6 +6468,7 @@
     },
     "node_modules/@solana/options": {
       "version": "2.0.0-rc.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0-rc.1",
@@ -6473,6 +6483,7 @@
     },
     "node_modules/@solana/pay": {
       "version": "0.2.6",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@solana/qr-code-styling": "^1.6.0",
@@ -6547,6 +6558,7 @@
     },
     "node_modules/@solana/qr-code-styling": {
       "version": "1.6.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "qrcode-generator": "^1.4.3"
@@ -7221,6 +7233,7 @@
     },
     "node_modules/@solana/spl-token": {
       "version": "0.4.14",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
@@ -7238,6 +7251,7 @@
     },
     "node_modules/@solana/spl-token-group": {
       "version": "0.0.7",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@solana/codecs": "2.0.0-rc.1"
@@ -7251,6 +7265,7 @@
     },
     "node_modules/@solana/spl-token-metadata": {
       "version": "0.1.6",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@solana/codecs": "2.0.0-rc.1"
@@ -7765,6 +7780,7 @@
     },
     "node_modules/@solana/web3.js": {
       "version": "1.98.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.0",
@@ -7786,6 +7802,7 @@
     },
     "node_modules/@solana/web3.js/node_modules/@solana/codecs-core": {
       "version": "2.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.3.0"
@@ -7799,6 +7816,7 @@
     },
     "node_modules/@solana/web3.js/node_modules/@solana/codecs-numbers": {
       "version": "2.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.3.0",
@@ -7813,6 +7831,7 @@
     },
     "node_modules/@solana/web3.js/node_modules/@solana/errors": {
       "version": "2.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
@@ -7830,6 +7849,7 @@
     },
     "node_modules/@solana/web3.js/node_modules/base-x": {
       "version": "3.0.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -7837,6 +7857,7 @@
     },
     "node_modules/@solana/web3.js/node_modules/bs58": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "base-x": "^3.0.2"
@@ -7844,6 +7865,7 @@
     },
     "node_modules/@solana/web3.js/node_modules/chalk": {
       "version": "5.6.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -7854,6 +7876,7 @@
     },
     "node_modules/@solana/web3.js/node_modules/commander": {
       "version": "14.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -7868,6 +7891,7 @@
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.17",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -7945,6 +7969,7 @@
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -8147,10 +8172,12 @@
     },
     "node_modules/@types/uuid": {
       "version": "8.3.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "7.4.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -9278,6 +9305,7 @@
     },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "humanize-ms": "^1.2.1"
@@ -10054,6 +10082,7 @@
     },
     "node_modules/bigint-buffer": {
       "version": "1.1.5",
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -10168,6 +10197,7 @@
     },
     "node_modules/borsh": {
       "version": "0.7.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bn.js": "^5.2.0",
@@ -10177,6 +10207,7 @@
     },
     "node_modules/borsh/node_modules/base-x": {
       "version": "3.0.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -10184,6 +10215,7 @@
     },
     "node_modules/borsh/node_modules/bs58": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "base-x": "^3.0.2"
@@ -11322,6 +11354,7 @@
     },
     "node_modules/delay": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -11758,10 +11791,12 @@
     },
     "node_modules/es6-promise": {
       "version": "4.2.8",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/es6-promisify": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es6-promise": "^4.0.3"
@@ -13126,6 +13161,7 @@
     },
     "node_modules/eyes": {
       "version": "0.1.8",
+      "dev": true,
       "engines": {
         "node": "> 0.1.90"
       }
@@ -13182,6 +13218,7 @@
     },
     "node_modules/fast-stable-stringify": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fastq": {
@@ -13867,6 +13904,7 @@
     },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
@@ -14473,6 +14511,7 @@
     },
     "node_modules/isomorphic-ws": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "ws": "*"
@@ -14578,6 +14617,7 @@
     },
     "node_modules/jayson": {
       "version": "4.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "^3.4.33",
@@ -14602,10 +14642,12 @@
     },
     "node_modules/jayson/node_modules/@types/node": {
       "version": "12.20.55",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jayson/node_modules/commander": {
       "version": "2.20.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-environment-node": {
@@ -14970,6 +15012,7 @@
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/json5": {
@@ -17183,6 +17226,7 @@
     },
     "node_modules/qrcode-generator": {
       "version": "1.5.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/qrcode-terminal": {
@@ -17402,6 +17446,7 @@
     },
     "node_modules/react-native-url-polyfill": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url-without-unicode": "8.0.0-3"
@@ -18353,6 +18398,7 @@
     },
     "node_modules/rpc-websockets": {
       "version": "9.2.0",
+      "dev": true,
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@swc/helpers": "^0.5.11",
@@ -18374,6 +18420,7 @@
     },
     "node_modules/rpc-websockets/node_modules/@types/ws": {
       "version": "8.18.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -18381,6 +18428,7 @@
     },
     "node_modules/rpc-websockets/node_modules/ws": {
       "version": "8.18.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -19082,10 +19130,12 @@
     },
     "node_modules/stream-chain": {
       "version": "2.2.5",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/stream-json": {
       "version": "1.9.1",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "stream-chain": "^2.2.5"
@@ -19349,6 +19399,7 @@
     },
     "node_modules/superstruct": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -19523,7 +19574,8 @@
       }
     },
     "node_modules/text-encoding-utf-8": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "node_modules/thenify": {
       "version": "3.3.1",

--- a/packages/atxp-express/src/index.ts
+++ b/packages/atxp-express/src/index.ts
@@ -29,5 +29,5 @@ export type {
 
 export {
   requirePayment,
-  atxpAccountId as getUserId
+  atxpAccountId
 } from '@atxp/server';

--- a/packages/atxp-express/src/index.ts
+++ b/packages/atxp-express/src/index.ts
@@ -28,5 +28,6 @@ export type {
 } from '@atxp/server';
 
 export {
-  requirePayment
+  requirePayment,
+  atxpAccountId as getUserId
 } from '@atxp/server';

--- a/packages/atxp-server/src/requirePayment.test.ts
+++ b/packages/atxp-server/src/requirePayment.test.ts
@@ -236,4 +236,90 @@ describe('requirePayment', () => {
     });
   });
 
+  describe('minimumPayment with price comparison', () => {
+    it('should use requested price when it exceeds minimumPayment for both charge and createPaymentRequest', async () => {
+      const paymentServer = TH.paymentServer({
+        charge: vi.fn().mockResolvedValue({success: false, requiredPaymentId: 'test-payment-request-id'})
+      });
+      const config = TH.config({
+        paymentServer,
+        minimumPayment: BigNumber(0.05) // Minimum is $0.05
+      });
+
+      await withATXPContext(config, new URL('https://example.com'), TH.tokenCheck(), async () => {
+        try {
+          await requirePayment({price: BigNumber(0.10)}); // Request $0.10, which is higher than minimum
+        } catch (err: any) {
+          expect(err.code).toBe(PAYMENT_REQUIRED_ERROR_CODE);
+
+          // Should use requested amount (0.10) for charge since it's higher than minimumPayment
+          expect(paymentServer.charge).toHaveBeenCalledWith({
+            destinations: [{
+              network: 'base',
+              currency: config.currency,
+              address: TH.DESTINATION,
+              amount: BigNumber(0.10) // Uses requested amount
+            }],
+            source: 'test-user',
+            payeeName: config.payeeName,
+          });
+
+          // Should also use requested amount (0.10) for createPaymentRequest since it's higher
+          expect(paymentServer.createPaymentRequest).toHaveBeenCalledWith({
+            destinations: [{
+              network: 'base',
+              currency: config.currency,
+              address: TH.DESTINATION,
+              amount: BigNumber(0.10) // Uses requested amount, not minimumPayment
+            }],
+            source: 'test-user',
+            payeeName: config.payeeName,
+          });
+        }
+      });
+    });
+
+    it('should use minimumPayment when it exceeds requested price for createPaymentRequest only', async () => {
+      const paymentServer = TH.paymentServer({
+        charge: vi.fn().mockResolvedValue({success: false, requiredPaymentId: 'test-payment-request-id'})
+      });
+      const config = TH.config({
+        paymentServer,
+        minimumPayment: BigNumber(0.05) // Minimum is $0.05
+      });
+
+      await withATXPContext(config, new URL('https://example.com'), TH.tokenCheck(), async () => {
+        try {
+          await requirePayment({price: BigNumber(0.01)}); // Request $0.01, which is lower than minimum
+        } catch (err: any) {
+          expect(err.code).toBe(PAYMENT_REQUIRED_ERROR_CODE);
+
+          // Should use requested amount (0.01) for charge
+          expect(paymentServer.charge).toHaveBeenCalledWith({
+            destinations: [{
+              network: 'base',
+              currency: config.currency,
+              address: TH.DESTINATION,
+              amount: BigNumber(0.01) // Uses requested amount for charge
+            }],
+            source: 'test-user',
+            payeeName: config.payeeName,
+          });
+
+          // Should use minimumPayment (0.05) for createPaymentRequest since it's higher
+          expect(paymentServer.createPaymentRequest).toHaveBeenCalledWith({
+            destinations: [{
+              network: 'base',
+              currency: config.currency,
+              address: TH.DESTINATION,
+              amount: BigNumber(0.05) // Uses minimumPayment since it's higher
+            }],
+            source: 'test-user',
+            payeeName: config.payeeName,
+          });
+        }
+      });
+    });
+  });
+
 });

--- a/packages/atxp-server/src/requirePayment.test.ts
+++ b/packages/atxp-server/src/requirePayment.test.ts
@@ -53,6 +53,7 @@ describe('requirePayment', () => {
       } catch (err: any) {
         expect(err.code).toBe(PAYMENT_REQUIRED_ERROR_CODE);
         expect(paymentServer.createPaymentRequest).toHaveBeenCalledWith({
+          amount: BigNumber(0.01),
           destinations: [{
             network: 'base',
             currency: config.currency,
@@ -154,6 +155,7 @@ describe('requirePayment', () => {
 
           // Should use minimumPayment (0.05) for createPaymentRequest
           expect(paymentServer.createPaymentRequest).toHaveBeenCalledWith({
+            amount: BigNumber(0.05),
             destinations: [{
               network: 'base',
               currency: config.currency,
@@ -222,6 +224,7 @@ describe('requirePayment', () => {
 
           // Should use the requested amount (0.01) for createPaymentRequest
           expect(paymentServer.createPaymentRequest).toHaveBeenCalledWith({
+            amount: BigNumber(0.01),
             destinations: [{
               network: 'base',
               currency: config.currency,
@@ -266,6 +269,7 @@ describe('requirePayment', () => {
 
           // Should also use requested amount (0.10) for createPaymentRequest since it's higher
           expect(paymentServer.createPaymentRequest).toHaveBeenCalledWith({
+            amount: BigNumber(0.10),
             destinations: [{
               network: 'base',
               currency: config.currency,
@@ -308,6 +312,7 @@ describe('requirePayment', () => {
 
           // Should use minimumPayment (0.05) for createPaymentRequest since it's higher
           expect(paymentServer.createPaymentRequest).toHaveBeenCalledWith({
+            amount: BigNumber(0.05),
             destinations: [{
               network: 'base',
               currency: config.currency,

--- a/packages/atxp-server/src/requirePayment.ts
+++ b/packages/atxp-server/src/requirePayment.ts
@@ -69,8 +69,10 @@ export async function requirePayment(paymentConfig: RequirePaymentConfig): Promi
     throw new Error('No user found');
   }
 
-  // Use minimumPayment if configured, otherwise use the requested price
-  const paymentAmount = config.minimumPayment || paymentConfig.price;
+  // Use the maximum of minimumPayment and requested price
+  const paymentAmount = config.minimumPayment && config.minimumPayment.isGreaterThan(paymentConfig.price)
+    ? config.minimumPayment
+    : paymentConfig.price;
 
   // Get payment destinations (with caching)
   const paymentAddresses = await getCachedPaymentDestinations(

--- a/packages/atxp-server/src/requirePayment.ts
+++ b/packages/atxp-server/src/requirePayment.ts
@@ -109,8 +109,9 @@ export async function requirePayment(paymentConfig: RequirePaymentConfig): Promi
   }
 
   // For createPaymentRequest, use the minimumPayment if configured
-  const paymentRequestCharge = {
+  const paymentRequest = {
     ...charge,
+    amount: paymentAmount,
     destinations: paymentAddresses.map(addr => ({
       network: addr.network,
       currency: config.currency,
@@ -119,7 +120,7 @@ export async function requirePayment(paymentConfig: RequirePaymentConfig): Promi
     }))
   };
 
-  const paymentId = await config.paymentServer.createPaymentRequest(paymentRequestCharge);
+  const paymentId = await config.paymentServer.createPaymentRequest(paymentRequest);
   config.logger.info(`Created payment request ${paymentId}`);
   throw paymentRequiredError(config.server, paymentId, paymentAmount);
 }

--- a/packages/atxp-server/src/serverConfig.test.ts
+++ b/packages/atxp-server/src/serverConfig.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { buildServerConfig } from './serverConfig.js';
+import { BigNumber } from 'bignumber.js';
+import { ChainPaymentDestination } from './paymentDestination.js';
+
+describe('buildServerConfig', () => {
+  describe('minimumPayment validation', () => {
+    it('should throw an error if minimumPayment exceeds $1.00', () => {
+      const paymentDestination = new ChainPaymentDestination('testDestination', 'base');
+
+      expect(() => {
+        buildServerConfig({
+          paymentDestination,
+          minimumPayment: BigNumber(1.01) // $1.01, should throw
+        });
+      }).toThrow('minimumPayment cannot exceed $1.00');
+
+      expect(() => {
+        buildServerConfig({
+          paymentDestination,
+          minimumPayment: BigNumber(5) // $5.00, should throw
+        });
+      }).toThrow('minimumPayment cannot exceed $1.00');
+    });
+
+    it('should allow minimumPayment of exactly $1.00', () => {
+      const paymentDestination = new ChainPaymentDestination('testDestination', 'base');
+
+      expect(() => {
+        buildServerConfig({
+          paymentDestination,
+          minimumPayment: BigNumber(1) // $1.00, should be allowed
+        });
+      }).not.toThrow();
+    });
+
+    it('should allow minimumPayment less than $1.00', () => {
+      const paymentDestination = new ChainPaymentDestination('testDestination', 'base');
+
+      expect(() => {
+        buildServerConfig({
+          paymentDestination,
+          minimumPayment: BigNumber(0.05) // $0.05, should be allowed
+        });
+      }).not.toThrow();
+
+      expect(() => {
+        buildServerConfig({
+          paymentDestination,
+          minimumPayment: BigNumber(0.99) // $0.99, should be allowed
+        });
+      }).not.toThrow();
+    });
+
+    it('should allow no minimumPayment', () => {
+      const paymentDestination = new ChainPaymentDestination('testDestination', 'base');
+
+      expect(() => {
+        buildServerConfig({
+          paymentDestination
+          // No minimumPayment provided
+        });
+      }).not.toThrow();
+    });
+  });
+});

--- a/packages/atxp-server/src/serverConfig.ts
+++ b/packages/atxp-server/src/serverConfig.ts
@@ -6,9 +6,9 @@ type RequiredATXPConfigFields = 'paymentDestination';
 type RequiredATXPConfig = Pick<ATXPConfig, RequiredATXPConfigFields>;
 type OptionalATXPConfig = Omit<ATXPConfig, RequiredATXPConfigFields>;
 export type ATXPArgs = RequiredATXPConfig & Partial<OptionalATXPConfig>;
-type BuildableATXPConfigFields = 'oAuthDb' | 'oAuthClient' | 'paymentServer' | 'logger';
+type BuildableATXPConfigFields = 'oAuthDb' | 'oAuthClient' | 'paymentServer' | 'logger' | 'minimumPayment';
 
-export const DEFAULT_CONFIG: Required<Omit<OptionalATXPConfig, BuildableATXPConfigFields | 'minimumPayment'>> = {
+export const DEFAULT_CONFIG: Required<Omit<OptionalATXPConfig, BuildableATXPConfigFields>> = {
   mountPath: '/',
   currency: 'USDC' as const,
   server: DEFAULT_AUTHORIZATION_SERVER,

--- a/packages/atxp-server/src/serverConfig.ts
+++ b/packages/atxp-server/src/serverConfig.ts
@@ -8,7 +8,7 @@ type OptionalATXPConfig = Omit<ATXPConfig, RequiredATXPConfigFields>;
 export type ATXPArgs = RequiredATXPConfig & Partial<OptionalATXPConfig>;
 type BuildableATXPConfigFields = 'oAuthDb' | 'oAuthClient' | 'paymentServer' | 'logger';
 
-export const DEFAULT_CONFIG: Required<Omit<OptionalATXPConfig, BuildableATXPConfigFields>> = {
+export const DEFAULT_CONFIG: Required<Omit<OptionalATXPConfig, BuildableATXPConfigFields | 'minimumPayment'>> = {
   mountPath: '/',
   currency: 'USDC' as const,
   server: DEFAULT_AUTHORIZATION_SERVER,

--- a/packages/atxp-server/src/serverConfig.ts
+++ b/packages/atxp-server/src/serverConfig.ts
@@ -22,6 +22,11 @@ export function buildServerConfig(args: ATXPArgs): ATXPConfig {
     throw new Error('paymentDestination is required');
   }
 
+  // Validate minimumPayment if provided
+  if (args.minimumPayment && args.minimumPayment.isGreaterThan(1)) {
+    throw new Error('minimumPayment cannot exceed $1.00');
+  }
+
   // Read environment variables at runtime, not module load time
   const envDefaults = {
     ...DEFAULT_CONFIG,

--- a/packages/atxp-server/src/types.ts
+++ b/packages/atxp-server/src/types.ts
@@ -1,5 +1,6 @@
 import { AuthorizationServerUrl, Currency, Logger, PaymentRequestData, UrlString, OAuthDb, TokenData, OAuthResourceClient } from "@atxp/common";
 import { PaymentDestination } from "./paymentDestination.js";
+import { BigNumber } from "bignumber.js";
 
 // https://github.com/modelcontextprotocol/typescript-sdk/blob/c6ac083b1b37b222b5bfba5563822daa5d03372e/src/types.ts
 // ctrl+f "method: z.literal(""
@@ -46,6 +47,7 @@ export type ATXPConfig = {
   oAuthDb: OAuthDb;
   oAuthClient: OAuthResourceClient;
   paymentServer: PaymentServer;
+  minimumPayment?: BigNumber;
 }
 
 

--- a/src/dev/resource.ts
+++ b/src/dev/resource.ts
@@ -5,8 +5,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { z } from 'zod';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { BigNumber } from 'bignumber.js';
-import { requirePayment, ChainPaymentDestination, ATXPPaymentDestination } from '@atxp/server';
-import { atxpExpress } from '@atxp/express';
+import { atxpExpress, getUserId, requirePayment, ATXPPaymentDestination } from '@atxp/express';
 import { ConsoleLogger, LogLevel } from '@atxp/common';
 import 'dotenv/config';
 
@@ -27,12 +26,13 @@ const getServer = () => {
       message: z.string().optional().describe('Message to secure'),
     },
     async ({ message }: { message?: string }): Promise<CallToolResult> => {
+      const userId = getUserId();
       await requirePayment({price: BigNumber(0.01)});
       return {
         content: [
           {
             type: 'text',
-            text: `Secure data: ${message || 'No message provided'}`,
+            text: `Secure data for user ${userId}: ${message || 'No message provided'}`,
           }
         ],
       };
@@ -45,20 +45,20 @@ const getServer = () => {
 const app = express();
 app.use(express.json());
 
+const logger = new ConsoleLogger({level: LogLevel.DEBUG});
+
 const destinationAddress = process.env.ATXP_DESTINATION!;
 //const destination = new ChainPaymentDestination(destinationAddress, 'base');
-const destination = new ATXPPaymentDestination(destinationAddress);
+const destination = new ATXPPaymentDestination(destinationAddress, { logger });
 
 console.log('Starting MCP server with destination', destinationAddress);
 app.use(atxpExpress({
   paymentDestination: destination,
-  resource: `http://localhost:${PORT}`,
   //server: 'http://localhost:3010',
-  server: 'https://auth.atxp.ai',
-  mountPath: '/',
   payeeName: 'ATXP Client Example Resource Server',
+  minimumPayment: BigNumber(0.05),
   allowHttp: true,
-  logger: new ConsoleLogger({level: LogLevel.DEBUG})
+  logger
 }));
 
 

--- a/src/dev/resource.ts
+++ b/src/dev/resource.ts
@@ -5,7 +5,7 @@ import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/
 import { z } from 'zod';
 import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
 import { BigNumber } from 'bignumber.js';
-import { atxpExpress, getUserId, requirePayment, ATXPPaymentDestination } from '@atxp/express';
+import { atxpExpress, atxpAccountId, requirePayment, ATXPPaymentDestination } from '@atxp/express';
 import { ConsoleLogger, LogLevel } from '@atxp/common';
 import 'dotenv/config';
 
@@ -26,7 +26,7 @@ const getServer = () => {
       message: z.string().optional().describe('Message to secure'),
     },
     async ({ message }: { message?: string }): Promise<CallToolResult> => {
-      const userId = getUserId();
+      const userId = atxpAccountId();
       await requirePayment({price: BigNumber(0.01)});
       return {
         content: [


### PR DESCRIPTION
Adds support for batch payments - payments that are more than the price of a single tool call. This allows the server to effectively request pre-payment for multiple tool calls in advance.

This is implemented via a new `minimumPayment` field on `atxpExpress`, which is the smallest payment that will be asked of callers. If not provided, the caller will always be asked to pay exactly the amount in `requirePayment`. If `minimumPayment` is larger, the user will be asked to pay that instead. To prevent footguns, this is limited to $1 at a maximum.

A new `/examples/batch-payment` example is included.