### PR TITLE
Remove root-level amount from payment request creation

### DIFF
--- a/packages/atxp-server/src/requirePayment.test.ts
+++ b/packages/atxp-server/src/requirePayment.test.ts
@@ -53,7 +53,6 @@ describe('requirePayment', () => {
       } catch (err: any) {
         expect(err.code).toBe(PAYMENT_REQUIRED_ERROR_CODE);
         expect(paymentServer.createPaymentRequest).toHaveBeenCalledWith({
-          amount: BigNumber(0.01),
           destinations: [{
             network: 'base',
             currency: config.currency,
@@ -155,7 +154,6 @@ describe('requirePayment', () => {
 
           // Should use minimumPayment (0.05) for createPaymentRequest
           expect(paymentServer.createPaymentRequest).toHaveBeenCalledWith({
-            amount: BigNumber(0.05),
             destinations: [{
               network: 'base',
               currency: config.currency,
@@ -224,7 +222,6 @@ describe('requirePayment', () => {
 
           // Should use the requested amount (0.01) for createPaymentRequest
           expect(paymentServer.createPaymentRequest).toHaveBeenCalledWith({
-            amount: BigNumber(0.01),
             destinations: [{
               network: 'base',
               currency: config.currency,
@@ -269,7 +266,6 @@ describe('requirePayment', () => {
 
           // Should also use requested amount (0.10) for createPaymentRequest since it's higher
           expect(paymentServer.createPaymentRequest).toHaveBeenCalledWith({
-            amount: BigNumber(0.10),
             destinations: [{
               network: 'base',
               currency: config.currency,
@@ -312,7 +308,6 @@ describe('requirePayment', () => {
 
           // Should use minimumPayment (0.05) for createPaymentRequest since it's higher
           expect(paymentServer.createPaymentRequest).toHaveBeenCalledWith({
-            amount: BigNumber(0.05),
             destinations: [{
               network: 'base',
               currency: config.currency,

--- a/packages/atxp-server/src/requirePayment.ts
+++ b/packages/atxp-server/src/requirePayment.ts
@@ -110,8 +110,8 @@ export async function requirePayment(paymentConfig: RequirePaymentConfig): Promi
 
   // For createPaymentRequest, use the minimumPayment if configured
   const paymentRequest = {
-    ...charge,
-    amount: paymentAmount,
+    source: charge.source,
+    payeeName: charge.payeeName,
     destinations: paymentAddresses.map(addr => ({
       network: addr.network,
       currency: config.currency,


### PR DESCRIPTION
The SDK now only includes the destinations array without a root-level amount field when creating payment requests. The root-level `amount` was added in https://github.com/atxp-dev/sdk/pull/75 in order to support old (pre v0.5.0) SDK clients that didn't parse payment destinations out of the responses, but that doesn't matter because that was a breaking change - old clients won't work regardless. So this cleans up the code to only support destinations.

v0.7.1 had a related bug in auth.atxp.ai that would only accept either the root-level amount/destination/network OR the destinations, but not both. https://github.com/circuitandchisel/auth/pull/96 fixed that, so SDK v0.7.1 shouldn't have issues anymore.