### PR TITLE
Add support for base_sepolia and world_sepolia testnet networks

### DIFF
--- a/packages/atxp-common/src/types.ts
+++ b/packages/atxp-common/src/types.ts
@@ -20,7 +20,7 @@ export type UrlString = `http://${string}` | `https://${string}`;
 export type AuthorizationServerUrl = UrlString;
 
 export type Currency = 'USDC';
-export type Network = 'solana' | 'base' | 'world';
+export type Network = 'solana' | 'base' | 'world' | 'base_sepolia' | 'world_sepolia';
 
 export type PaymentRequestDestination = {
   network: Network;

--- a/packages/atxp-server/src/paymentDestination.ts
+++ b/packages/atxp-server/src/paymentDestination.ts
@@ -110,6 +110,12 @@ export class ATXPPaymentDestination implements PaymentDestination {
       case 'base':
         network = 'base'; // Already correct
         break;
+      case 'base_sepolia':
+        network = 'base_sepolia';
+        break;
+      case 'world_sepolia':
+        network = 'world_sepolia';
+        break;
       case 'solana':
         network = 'solana';
         break;
@@ -175,7 +181,9 @@ export class ATXPPaymentDestination implements PaymentDestination {
           network = 'base'; // Base is an Ethereum L2
           break;
         case 'base':
+        case 'base_sepolia':
         case 'world':
+        case 'world_sepolia':
         case 'solana':
           network = networkFromItem
           break;


### PR DESCRIPTION
## Summary

- Added `base_sepolia` and `world_sepolia` to the `Network` type in `@atxp/common`
- Updated network mapping logic in `paymentDestination.ts` to handle these testnet networks
- Fixes the "Unknown network: base_sepolia, skipping" and "Unknown network: world_sepolia, skipping" warnings that testnet users were seeing

## Changes

- `packages/atxp-common/src/types.ts`: Extended `Network` type to include testnet networks
- `packages/atxp-server/src/paymentDestination.ts`: Added case handlers for `base_sepolia` and `world_sepolia` in both the `destination` and `destinations` methods

## Test plan

- [ ] Verify testnet users no longer see "Unknown network" warnings for base_sepolia and world_sepolia
- [ ] Confirm testnet transactions work correctly with these networks
- [ ] Ensure no regression with existing mainnet networks (base, world, solana)

Closes ATXP-335

🤖 Generated with [Claude Code](https://claude.com/claude-code)