### PR TITLE
Remove destination() method and use /addresses endpoint exclusively

### DIFF
--- a/packages/atxp-server/src/requirePayment.ts
+++ b/packages/atxp-server/src/requirePayment.ts
@@ -38,15 +38,7 @@ async function getCachedPaymentDestinations(
   config.logger.debug(`Fetching payment destinations for user ${user}`);
 
   const fundingAmount: FundingAmount = { amount, currency };
-  let paymentAddresses: PaymentAddress[];
-
-  if ('destinations' in config.paymentDestination && typeof config.paymentDestination.destinations === 'function') {
-    paymentAddresses = await config.paymentDestination.destinations(fundingAmount, user);
-  } else {
-    // Fallback to single destination wrapped in array
-    const singleAddress = await config.paymentDestination.destination(fundingAmount, user);
-    paymentAddresses = [singleAddress];
-  }
+  const paymentAddresses = await config.paymentDestination.destinations(fundingAmount, user);
 
   // Cache the result
   destinationCache.set(cacheKey, {


### PR DESCRIPTION
## Summary

Removes the `destination()` method from the PaymentDestination interface and implementations, making the SDK use only the `/addresses` endpoint for all payment destination lookups.

## Changes

- **PaymentDestination Interface**: Removed `destination()` method, now only has `destinations()`
- **ChainPaymentDestination**: Removed `destination()` implementation, simplified `destinations()` to return array directly
- **ATXPPaymentDestination**: Removed `destination()` implementation that was calling `/destination` endpoint
- **requirePayment**: Removed fallback logic, now always calls `destinations()`
- **Tests**: Updated all 14 tests to use `destinations()` and expect arrays

## Test Results

✅ All 126 tests in atxp-server package pass

## Related

Closes ATXP-339

🤖 Generated with [Claude Code](https://claude.com/claude-code)