### PR TITLE
Fix build issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6011,6 +6011,7 @@
     },
     "node_modules/@solana/buffer-layout": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer": "~6.0.3"
@@ -6021,6 +6022,7 @@
     },
     "node_modules/@solana/buffer-layout-utils": {
       "version": "0.2.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
@@ -6034,6 +6036,7 @@
     },
     "node_modules/@solana/codecs": {
       "version": "2.0.0-rc.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0-rc.1",
@@ -6048,6 +6051,7 @@
     },
     "node_modules/@solana/codecs-core": {
       "version": "2.0.0-rc.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.0.0-rc.1"
@@ -6058,6 +6062,7 @@
     },
     "node_modules/@solana/codecs-data-structures": {
       "version": "2.0.0-rc.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0-rc.1",
@@ -6070,6 +6075,7 @@
     },
     "node_modules/@solana/codecs-numbers": {
       "version": "2.0.0-rc.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0-rc.1",
@@ -6081,6 +6087,7 @@
     },
     "node_modules/@solana/codecs-strings": {
       "version": "2.0.0-rc.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0-rc.1",
@@ -6094,6 +6101,7 @@
     },
     "node_modules/@solana/errors": {
       "version": "2.0.0-rc.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",
@@ -6108,6 +6116,7 @@
     },
     "node_modules/@solana/errors/node_modules/chalk": {
       "version": "5.6.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -6459,6 +6468,7 @@
     },
     "node_modules/@solana/options": {
       "version": "2.0.0-rc.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.0.0-rc.1",
@@ -6473,6 +6483,7 @@
     },
     "node_modules/@solana/pay": {
       "version": "0.2.6",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@solana/qr-code-styling": "^1.6.0",
@@ -6547,6 +6558,7 @@
     },
     "node_modules/@solana/qr-code-styling": {
       "version": "1.6.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "qrcode-generator": "^1.4.3"
@@ -7221,6 +7233,7 @@
     },
     "node_modules/@solana/spl-token": {
       "version": "0.4.14",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
@@ -7238,6 +7251,7 @@
     },
     "node_modules/@solana/spl-token-group": {
       "version": "0.0.7",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@solana/codecs": "2.0.0-rc.1"
@@ -7251,6 +7265,7 @@
     },
     "node_modules/@solana/spl-token-metadata": {
       "version": "0.1.6",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@solana/codecs": "2.0.0-rc.1"
@@ -7765,6 +7780,7 @@
     },
     "node_modules/@solana/web3.js": {
       "version": "1.98.4",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.25.0",
@@ -7786,6 +7802,7 @@
     },
     "node_modules/@solana/web3.js/node_modules/@solana/codecs-core": {
       "version": "2.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/errors": "2.3.0"
@@ -7799,6 +7816,7 @@
     },
     "node_modules/@solana/web3.js/node_modules/@solana/codecs-numbers": {
       "version": "2.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@solana/codecs-core": "2.3.0",
@@ -7813,6 +7831,7 @@
     },
     "node_modules/@solana/web3.js/node_modules/@solana/errors": {
       "version": "2.3.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
@@ -7830,6 +7849,7 @@
     },
     "node_modules/@solana/web3.js/node_modules/base-x": {
       "version": "3.0.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -7837,6 +7857,7 @@
     },
     "node_modules/@solana/web3.js/node_modules/bs58": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "base-x": "^3.0.2"
@@ -7844,6 +7865,7 @@
     },
     "node_modules/@solana/web3.js/node_modules/chalk": {
       "version": "5.6.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -7854,6 +7876,7 @@
     },
     "node_modules/@solana/web3.js/node_modules/commander": {
       "version": "14.0.1",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -7868,6 +7891,7 @@
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.17",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -7945,6 +7969,7 @@
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -8147,10 +8172,12 @@
     },
     "node_modules/@types/uuid": {
       "version": "8.3.4",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/ws": {
       "version": "7.4.7",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -9278,6 +9305,7 @@
     },
     "node_modules/agentkeepalive": {
       "version": "4.6.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "humanize-ms": "^1.2.1"
@@ -10054,6 +10082,7 @@
     },
     "node_modules/bigint-buffer": {
       "version": "1.1.5",
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -10168,6 +10197,7 @@
     },
     "node_modules/borsh": {
       "version": "0.7.0",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "bn.js": "^5.2.0",
@@ -10177,6 +10207,7 @@
     },
     "node_modules/borsh/node_modules/base-x": {
       "version": "3.0.11",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -10184,6 +10215,7 @@
     },
     "node_modules/borsh/node_modules/bs58": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "base-x": "^3.0.2"
@@ -11322,6 +11354,7 @@
     },
     "node_modules/delay": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -11758,10 +11791,12 @@
     },
     "node_modules/es6-promise": {
       "version": "4.2.8",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/es6-promisify": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es6-promise": "^4.0.3"
@@ -13126,6 +13161,7 @@
     },
     "node_modules/eyes": {
       "version": "0.1.8",
+      "dev": true,
       "engines": {
         "node": "> 0.1.90"
       }
@@ -13182,6 +13218,7 @@
     },
     "node_modules/fast-stable-stringify": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fastq": {
@@ -13867,6 +13904,7 @@
     },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
@@ -14473,6 +14511,7 @@
     },
     "node_modules/isomorphic-ws": {
       "version": "4.0.1",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "ws": "*"
@@ -14578,6 +14617,7 @@
     },
     "node_modules/jayson": {
       "version": "4.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/connect": "^3.4.33",
@@ -14602,10 +14642,12 @@
     },
     "node_modules/jayson/node_modules/@types/node": {
       "version": "12.20.55",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jayson/node_modules/commander": {
       "version": "2.20.3",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/jest-environment-node": {
@@ -14970,6 +15012,7 @@
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/json5": {
@@ -17183,6 +17226,7 @@
     },
     "node_modules/qrcode-generator": {
       "version": "1.5.2",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/qrcode-terminal": {
@@ -17402,6 +17446,7 @@
     },
     "node_modules/react-native-url-polyfill": {
       "version": "2.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url-without-unicode": "8.0.0-3"
@@ -18353,6 +18398,7 @@
     },
     "node_modules/rpc-websockets": {
       "version": "9.2.0",
+      "dev": true,
       "license": "LGPL-3.0-only",
       "dependencies": {
         "@swc/helpers": "^0.5.11",
@@ -18374,6 +18420,7 @@
     },
     "node_modules/rpc-websockets/node_modules/@types/ws": {
       "version": "8.18.1",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -18381,6 +18428,7 @@
     },
     "node_modules/rpc-websockets/node_modules/ws": {
       "version": "8.18.3",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
@@ -19082,10 +19130,12 @@
     },
     "node_modules/stream-chain": {
       "version": "2.2.5",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/stream-json": {
       "version": "1.9.1",
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "stream-chain": "^2.2.5"
@@ -19349,6 +19399,7 @@
     },
     "node_modules/superstruct": {
       "version": "2.0.2",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -19523,7 +19574,8 @@
       }
     },
     "node_modules/text-encoding-utf-8": {
-      "version": "1.0.2"
+      "version": "1.0.2",
+      "dev": true
     },
     "node_modules/thenify": {
       "version": "3.3.1",

--- a/packages/atxp-x402/rollup.config.js
+++ b/packages/atxp-x402/rollup.config.js
@@ -4,6 +4,7 @@ export default createConfig('atxp-x402', {
   platform: 'neutral', // Browser/React Native
   external: [
     // x402 and its dependencies
-    'x402'
+    'x402',
+    'x402/client'
   ]
 });

--- a/packages/atxp-x402/src/x402Wrapper.test.ts
+++ b/packages/atxp-x402/src/x402Wrapper.test.ts
@@ -66,6 +66,7 @@ describe('wrapWithX402', () => {
 
     expect(() => {
       wrapWithX402({
+        mcpServer: 'https://example.com/mcp',
         account: nonATXPAccount as any,
         fetchFn: mockFetch,
         logger: mockLogger,
@@ -78,6 +79,7 @@ describe('wrapWithX402', () => {
     mockFetch.mockResolvedValue(mockResponse);
 
     const wrappedFetch = wrapWithX402({
+      mcpServer: 'https://example.com/mcp',
       account: mockAccount,
       fetchFn: mockFetch,
       logger: mockLogger,
@@ -125,6 +127,7 @@ describe('wrapWithX402', () => {
       .mockResolvedValueOnce(successResponse);
 
     const wrappedFetch = wrapWithX402({
+      mcpServer: 'https://example.com/mcp',
       account: mockAccount,
       fetchFn: mockFetch,
       logger: mockLogger,
@@ -200,6 +203,7 @@ describe('wrapWithX402', () => {
     mockApprovePayment.mockResolvedValue(false);
 
     const wrappedFetch = wrapWithX402({
+      mcpServer: 'https://example.com/mcp',
       account: mockAccount,
       fetchFn: mockFetch,
       logger: mockLogger,
@@ -241,6 +245,7 @@ describe('wrapWithX402', () => {
     mockFetch.mockResolvedValue(response402);
 
     const wrappedFetch = wrapWithX402({
+      mcpServer: 'https://example.com/mcp',
       account: mockAccount,
       fetchFn: mockFetch,
       logger: mockLogger,
@@ -285,6 +290,7 @@ describe('wrapWithX402', () => {
     mockAccount.getSigner = vi.fn().mockRejectedValue(new Error('Signer error'));
 
     const wrappedFetch = wrapWithX402({
+      mcpServer: 'https://example.com/mcp',
       account: mockAccount,
       fetchFn: mockFetch,
       logger: mockLogger,
@@ -340,6 +346,7 @@ describe('wrapWithX402', () => {
     mockFetch.mockResolvedValue(response402);
 
     const wrappedFetch = wrapWithX402({
+      mcpServer: 'https://example.com/mcp',
       account: mockAccount,
       fetchFn: mockFetch,
       logger: mockLogger,

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,6 +30,7 @@ const createConfig = (packageName, options = {}) => {
     // Check regex patterns for deep imports
     const patterns = [
       /^viem/, // All viem imports including deep paths
+      /^x402/, // All x402 imports including subpath exports like x402/client
       /^@solana\/web3\.js/, /^@solana\/pay/, /^@solana\/buffer-layout/, /^@solana\/spl-token/,
       /^bs58/, /^react-native-url-polyfill/, /^expo-crypto/, /^@base-org\/account/
     ];
@@ -56,19 +57,8 @@ const createConfig = (packageName, options = {}) => {
 
   const plugins = [
     typescript({
-      tsconfig: false,
-      compilerOptions: {
-        target: 'es2020',
-        module: 'esnext',
-        lib: ['es2020', 'dom'],
-        moduleResolution: 'node',
-        allowSyntheticDefaultImports: true,
-        esModuleInterop: true,
-        skipLibCheck: true,
-        strict: true,
-        declaration: false,
-        sourceMap: true
-      }
+      tsconfig: './tsconfig.json',
+      exclude: ['**/*.test.ts', '**/*.spec.ts']
     }),
     resolve({
       preferBuiltins: platform === 'node',


### PR DESCRIPTION
Doing a fresh clone of the repo, npm i, and npm run build was generating these errors:
```
(!) [plugin typescript] src/x402Wrapper.test.ts (342:39): @rollup/plugin-typescript TS2345: Argument of type '{ account: ATXPAccount; fetchFn: Mock<Procedure>; logger: ConsoleLogger; onPaymentFailure: Mock<Procedure>; }' is not assignable to parameter of type 'ClientArgs'.
  Property 'mcpServer' is missing in type '{ account: ATXPAccount; fetchFn: Mock<Procedure>; logger: ConsoleLogger; onPaymentFailure: Mock<Procedure>; }' but required in type 'RequiredClientConfig'.
/Users/bdj/code/sdk/packages/atxp-x402/src/x402Wrapper.test.ts:342:39

342     const wrappedFetch = wrapWithX402({
                                          ~
343       account: mockAccount,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
... 
346       onPaymentFailure: mockOnPaymentFailure,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
347     });
    ~~~~~

  ../atxp-client/dist/index.d.ts:29:5
    29     mcpServer: string;
           ~~~~~~~~~
    'mcpServer' is declared here.

(!) [plugin typescript] src/x402Wrapper.ts (4:64): @rollup/plugin-typescript TS2307: Cannot find module 'x402/client' or its corresponding type declarations.
/Users/bdj/code/sdk/packages/atxp-x402/src/x402Wrapper.ts:4:64

4 import { createPaymentHeader, selectPaymentRequirements } from 'x402/client';
```

I pointed Claude at it and it came up with this justification:

The fix was to update the rollup configuration to:
1. Use the actual tsconfig.json file instead of inline TypeScript configuration
2. Explicitly exclude test files from TypeScript compilation

This allows the TypeScript plugin to:
- Respect the project references defined in tsconfig.json
- Properly resolve the @atxp/server/serverTestHelpers subpath export
- Avoid trying to compile test files during the build

The key change was in rollup.config.js:
```
typescript({
  tsconfig: './tsconfig.json',
  exclude: ['**/*.test.ts', '**/*.spec.ts']
}),
```
This ensures that the TypeScript plugin uses the same configuration as the rest of the project, including the proper module resolution for package exports.