### PR TITLE
Restore "Naveen/server registration - Developer Token Implementation …

### DIFF
--- a/examples/batch-payments/src/index.ts
+++ b/examples/batch-payments/src/index.ts
@@ -11,6 +11,14 @@ import { atxpExpress, requirePayment, atxpAccountId, ATXPPaymentDestination } fr
 const PORT = process.env.PORT ? parseInt(process.env.PORT) : 3011;
 
 async function main() {
+  // Validate required environment variables
+  if (!process.env.ATXP_DEVELOPER_TOKEN) {
+    console.error('❌ Missing required environment variable: ATXP_DEVELOPER_TOKEN');
+    console.error('   Please obtain your developer token from https://accounts.atxp.ai/');
+    console.error('   and add it to your .env file:');
+    console.error('   ATXP_DEVELOPER_TOKEN=atxp_dev_...');
+    process.exit(1);
+  }
   const server = new McpServer({
     name: 'batch-payments-example',
     version: '1.0.0',
@@ -57,7 +65,8 @@ async function main() {
     paymentDestination,
     payeeName: 'Batch Payments Example',
     allowHttp: process.env.NODE_ENV === 'development',
-    minimumPayment: BigNumber(0.05)
+    minimumPayment: BigNumber(0.05),
+    atxpDeveloperToken: process.env.ATXP_DEVELOPER_TOKEN!,
   });
 
   app.use(atxpRouter as any);

--- a/examples/multichain/.env.example
+++ b/examples/multichain/.env.example
@@ -2,6 +2,7 @@
 PORT=3009
 ATXP_DESTINATION=http://localhost:3000/?connection_token=your_connection_token
 ATXP_AUTH_SERVER=https://auth.atxp.ai
+ATXP_DEVELOPER_TOKEN=dev_token_test789
 
 # Base chain configuration for test client
 BASE_RPC=https://mainnet.base.org

--- a/examples/multichain/src/server.ts
+++ b/examples/multichain/src/server.ts
@@ -49,6 +49,15 @@ const getServer = () => {
   return server;
 }
 
+// Validate required environment variables
+if (!process.env.ATXP_DEVELOPER_TOKEN) {
+  console.error('❌ Missing required environment variable: ATXP_DEVELOPER_TOKEN');
+  console.error('   Please obtain your developer token from https://accounts.atxp.ai/developer');
+  console.error('   and add it to your .env file:');
+  console.error('   ATXP_DEVELOPER_TOKEN=atxp_dev_...');
+  process.exit(1);
+}
+
 const app = express();
 app.use(express.json());
 
@@ -67,7 +76,8 @@ const atxpRouter = atxpExpress({
   mountPath: '/',
   payeeName: 'Multichain Example Server',
   allowHttp: true,
-  logger: new ConsoleLogger({level: LogLevel.DEBUG})
+  logger: new ConsoleLogger({level: LogLevel.DEBUG}),
+  atxpDeveloperToken: process.env.ATXP_DEVELOPER_TOKEN!,
 });
 
 app.use(atxpRouter as any);

--- a/examples/server/src/index.ts
+++ b/examples/server/src/index.ts
@@ -14,6 +14,15 @@ const PORT = process.env.PORT ? parseInt(process.env.PORT) : 3010;
 
 // Validate required environment variables
 function validateEnvironment() {
+  // Check for developer token (required)
+  if (!process.env.ATXP_DEVELOPER_TOKEN) {
+    console.error('❌ Missing required environment variable: ATXP_DEVELOPER_TOKEN');
+    console.error('   Please obtain your developer token from https://accounts.atxp.ai/');
+    console.error('   and add it to your .env file:');
+    console.error('   ATXP_DEVELOPER_TOKEN=atxp_dev_...');
+    process.exit(1);
+  }
+
   // Support either ATXP connection string OR static funding destination
   const hasAtxpConnection = process.env.ATXP_CONNECTION_STRING;
   const hasStaticFunding = process.env.FUNDING_DESTINATION && process.env.FUNDING_NETWORK;
@@ -105,6 +114,7 @@ async function main() {
     paymentDestination,
     payeeName: 'ATXP Server Example',
     allowHttp: process.env.NODE_ENV === 'development',
+    atxpDeveloperToken: process.env.ATXP_DEVELOPER_TOKEN!,
   });
   
   // Use the router as middleware - Express v5 compatibility

--- a/packages/atxp-express/src/atxpExpress.test.ts
+++ b/packages/atxp-express/src/atxpExpress.test.ts
@@ -8,10 +8,18 @@ import request from 'supertest';
 describe('ATXP', () => {
   it('should run code at request start and finish', async () => {
     const logger = TH.logger();
-    const router = atxpExpress(TH.config({
-      logger, 
+    const config = TH.config({
+      logger,
       oAuthClient: TH.oAuthClient({introspectResult: TH.tokenData({active: true})})
-    }));
+    });
+    const router = atxpExpress({
+      paymentDestination: config.paymentDestination,
+      atxpDeveloperToken: config.atxpDeveloperToken,
+      logger: config.logger,
+      oAuthClient: config.oAuthClient,
+      oAuthDb: config.oAuthDb,
+      paymentServer: config.paymentServer
+    });
 
     const app = express();
     app.use(express.json());
@@ -37,10 +45,18 @@ describe('ATXP', () => {
   it('should run code at start and finish if sending an OAuth challenge', async () => {
     const badToken = TH.tokenData({active: false});
     const logger = TH.logger();
-    const router = atxpExpress(TH.config({
-      logger, 
+    const config = TH.config({
+      logger,
       oAuthClient: TH.oAuthClient({introspectResult: badToken})
-    }));
+    });
+    const router = atxpExpress({
+      paymentDestination: config.paymentDestination,
+      atxpDeveloperToken: config.atxpDeveloperToken,
+      logger: config.logger,
+      oAuthClient: config.oAuthClient,
+      oAuthDb: config.oAuthDb,
+      paymentServer: config.paymentServer
+    });
 
     const app = express();
     app.use(express.json());
@@ -65,10 +81,18 @@ describe('ATXP', () => {
   it('should save the oAuth token in the DB if it is active', async () => {
     const goodToken = TH.tokenData({active: true, sub: 'test-user'});
     const oAuthDb = new MemoryOAuthDb();
-    const router = atxpExpress(TH.config({
+    const config = TH.config({
       oAuthClient: TH.oAuthClient({introspectResult: goodToken}),
       oAuthDb
-    }));
+    });
+    const router = atxpExpress({
+      paymentDestination: config.paymentDestination,
+      atxpDeveloperToken: config.atxpDeveloperToken,
+      logger: config.logger,
+      oAuthClient: config.oAuthClient,
+      oAuthDb: config.oAuthDb,
+      paymentServer: config.paymentServer
+    });
 
     const app = express();
     app.use(express.json());
@@ -96,9 +120,17 @@ describe('ATXP', () => {
   
   it('should return an OAuth challenge if token not active', async () => {
     const badToken = TH.tokenData({active: false});
-    const router = atxpExpress(TH.config({
+    const config = TH.config({
       oAuthClient: TH.oAuthClient({introspectResult: badToken})
-    }));
+    });
+    const router = atxpExpress({
+      paymentDestination: config.paymentDestination,
+      atxpDeveloperToken: config.atxpDeveloperToken,
+      logger: config.logger,
+      oAuthClient: config.oAuthClient,
+      oAuthDb: config.oAuthDb,
+      paymentServer: config.paymentServer
+    });
 
     const app = express();
     app.use(express.json());
@@ -120,9 +152,15 @@ describe('ATXP', () => {
   });
 
   it('should not intercept non-MCP requests', async () => {
-    const router = atxpExpress(TH.config({
-      destination: 'test-destination',
-    }));
+    const config = TH.config({});
+    const router = atxpExpress({
+      paymentDestination: config.paymentDestination,
+      atxpDeveloperToken: config.atxpDeveloperToken,
+      logger: config.logger,
+      oAuthClient: config.oAuthClient,
+      oAuthDb: config.oAuthDb,
+      paymentServer: config.paymentServer
+    });
 
     const app = express();
     app.use(express.json());
@@ -142,9 +180,15 @@ describe('ATXP', () => {
   });
 
   it('serves PRM endpoint', async () => {
-    const router = atxpExpress(TH.config({
-      destination: 'test-destination',
-    }));
+    const config = TH.config({});
+    const router = atxpExpress({
+      paymentDestination: config.paymentDestination,
+      atxpDeveloperToken: config.atxpDeveloperToken,
+      logger: config.logger,
+      oAuthClient: config.oAuthClient,
+      oAuthDb: config.oAuthDb,
+      paymentServer: config.paymentServer
+    });
 
     const app = express();
     app.use(express.json());
@@ -157,7 +201,7 @@ describe('ATXP', () => {
     // Check the response data
     expect(response.body).toMatchObject({
       resource: expect.stringMatching(/^https?:\/\/127\.0\.0\.1:\d+\/$/),
-      resource_name: 'Test ATXP Server',
+      resource_name: 'An ATXP Server',
       authorization_servers: ['https://auth.atxp.ai'],
       bearer_methods_supported: ['header'],
       scopes_supported: ['read', 'write'],

--- a/packages/atxp-server/src/serverConfig.test.ts
+++ b/packages/atxp-server/src/serverConfig.test.ts
@@ -4,6 +4,28 @@ import { BigNumber } from 'bignumber.js';
 import { ChainPaymentDestination } from './paymentDestination.js';
 
 describe('buildServerConfig', () => {
+  const TEST_DEVELOPER_TOKEN = 'atxp_dev_test123456789';
+
+  describe('required fields validation', () => {
+    it('should throw an error if paymentDestination is missing', () => {
+      expect(() => {
+        buildServerConfig({
+          atxpDeveloperToken: TEST_DEVELOPER_TOKEN
+        } as any);
+      }).toThrow('paymentDestination is required');
+    });
+
+    it('should throw an error if atxpDeveloperToken is missing', () => {
+      const paymentDestination = new ChainPaymentDestination('testDestination', 'base');
+
+      expect(() => {
+        buildServerConfig({
+          paymentDestination
+        } as any);
+      }).toThrow('atxpDeveloperToken is required');
+    });
+  });
+
   describe('minimumPayment validation', () => {
     it('should throw an error if minimumPayment exceeds $1.00', () => {
       const paymentDestination = new ChainPaymentDestination('testDestination', 'base');
@@ -11,6 +33,7 @@ describe('buildServerConfig', () => {
       expect(() => {
         buildServerConfig({
           paymentDestination,
+          atxpDeveloperToken: TEST_DEVELOPER_TOKEN,
           minimumPayment: BigNumber(1.01) // $1.01, should throw
         });
       }).toThrow('minimumPayment cannot exceed $1.00');
@@ -18,6 +41,7 @@ describe('buildServerConfig', () => {
       expect(() => {
         buildServerConfig({
           paymentDestination,
+          atxpDeveloperToken: TEST_DEVELOPER_TOKEN,
           minimumPayment: BigNumber(5) // $5.00, should throw
         });
       }).toThrow('minimumPayment cannot exceed $1.00');
@@ -29,6 +53,7 @@ describe('buildServerConfig', () => {
       expect(() => {
         buildServerConfig({
           paymentDestination,
+          atxpDeveloperToken: TEST_DEVELOPER_TOKEN,
           minimumPayment: BigNumber(1) // $1.00, should be allowed
         });
       }).not.toThrow();
@@ -40,6 +65,7 @@ describe('buildServerConfig', () => {
       expect(() => {
         buildServerConfig({
           paymentDestination,
+          atxpDeveloperToken: TEST_DEVELOPER_TOKEN,
           minimumPayment: BigNumber(0.05) // $0.05, should be allowed
         });
       }).not.toThrow();
@@ -47,6 +73,7 @@ describe('buildServerConfig', () => {
       expect(() => {
         buildServerConfig({
           paymentDestination,
+          atxpDeveloperToken: TEST_DEVELOPER_TOKEN,
           minimumPayment: BigNumber(0.99) // $0.99, should be allowed
         });
       }).not.toThrow();
@@ -57,7 +84,8 @@ describe('buildServerConfig', () => {
 
       expect(() => {
         buildServerConfig({
-          paymentDestination
+          paymentDestination,
+          atxpDeveloperToken: TEST_DEVELOPER_TOKEN
           // No minimumPayment provided
         });
       }).not.toThrow();

--- a/packages/atxp-server/src/serverConfig.ts
+++ b/packages/atxp-server/src/serverConfig.ts
@@ -2,7 +2,7 @@ import { ConsoleLogger, OAuthResourceClient, DEFAULT_AUTHORIZATION_SERVER, Memor
 import { ATXPConfig } from "./types.js";
 import { ATXPPaymentServer } from "./paymentServer.js";
 
-type RequiredATXPConfigFields = 'paymentDestination';
+type RequiredATXPConfigFields = 'paymentDestination' | 'atxpDeveloperToken';
 type RequiredATXPConfig = Pick<ATXPConfig, RequiredATXPConfigFields>;
 type OptionalATXPConfig = Omit<ATXPConfig, RequiredATXPConfigFields>;
 export type ATXPArgs = RequiredATXPConfig & Partial<OptionalATXPConfig>;
@@ -21,6 +21,9 @@ export function buildServerConfig(args: ATXPArgs): ATXPConfig {
   if(!args.paymentDestination) {
     throw new Error('paymentDestination is required');
   }
+  if(!args.atxpDeveloperToken) {
+    throw new Error('atxpDeveloperToken is required');
+  }
 
   // Validate minimumPayment if provided
   if (args.minimumPayment && args.minimumPayment.isGreaterThan(1)) {
@@ -33,11 +36,13 @@ export function buildServerConfig(args: ATXPArgs): ATXPConfig {
     allowHttp: process.env.NODE_ENV === 'development',
   };
   const withDefaults = { ...envDefaults, ...args };
+
   const oAuthDb = withDefaults.oAuthDb ?? new MemoryOAuthDb()
   const oAuthClient = withDefaults.oAuthClient ?? new OAuthResourceClient({
     db: oAuthDb,
     allowInsecureRequests: withDefaults.allowHttp,
     clientName: withDefaults.payeeName,
+    atxpDeveloperToken: withDefaults.atxpDeveloperToken,
   });
   const logger = withDefaults.logger ?? new ConsoleLogger();
   const paymentServer = withDefaults.paymentServer ?? new ATXPPaymentServer(withDefaults.server, logger)

--- a/packages/atxp-server/src/serverTestHelpers.ts
+++ b/packages/atxp-server/src/serverTestHelpers.ts
@@ -67,6 +67,7 @@ export function config(args: Partial<ATXPConfig> = {}): ATXPConfig {
     oAuthClient,
     paymentServer: args.paymentServer ?? paymentServer(),
     logger: args.logger ?? mockLogger,
+    atxpDeveloperToken: args.atxpDeveloperToken ?? 'atxp_dev_test123456789',
     ...args
   };
 

--- a/packages/atxp-server/src/types.ts
+++ b/packages/atxp-server/src/types.ts
@@ -48,6 +48,8 @@ export type ATXPConfig = {
   oAuthClient: OAuthResourceClient;
   paymentServer: PaymentServer;
   minimumPayment?: BigNumber;
+  // Developer token for OAuth Dynamic Client Registration verification
+  atxpDeveloperToken: string;
 }
 
 

--- a/src/dev/resource.ts
+++ b/src/dev/resource.ts
@@ -47,6 +47,15 @@ app.use(express.json());
 
 const logger = new ConsoleLogger({level: LogLevel.DEBUG});
 
+// Validate required environment variables
+if (!process.env.ATXP_DEVELOPER_TOKEN) {
+  console.error('❌ Missing required environment variable: ATXP_DEVELOPER_TOKEN');
+  console.error('   Please obtain your developer token from https://accounts.atxp.ai/developer');
+  console.error('   and add it to your .env file:');
+  console.error('   ATXP_DEVELOPER_TOKEN=atxp_dev_...');
+  process.exit(1);
+}
+
 const destinationAddress = process.env.ATXP_DESTINATION!;
 //const destination = new ChainPaymentDestination(destinationAddress, 'base');
 const destination = new ATXPPaymentDestination(destinationAddress, { logger });
@@ -58,7 +67,8 @@ app.use(atxpExpress({
   payeeName: 'ATXP Client Example Resource Server',
   minimumPayment: BigNumber(0.05),
   allowHttp: true,
-  logger
+  logger,
+  atxpDeveloperToken: process.env.ATXP_DEVELOPER_TOKEN,
 }));
 
 


### PR DESCRIPTION
…in the SDK (#91)"

This reverts commit 25688dd69a0f4ad4ac838ebc7e34bc6332a0cb67.

This PR restores the changes from https://github.com/atxp-dev/sdk/pull/91 - I jumped the gun merging that because the server-side pieces haven't deployed yet. 

Probably it won't matter, so long as nobody publishes a new version of the SDK before the server changes land (ETA later today). But I've temporarily rolled that back anyways - main should be publishable at all times.

This should not be merged until https://github.com/circuitandchisel/accounts/pull/79 and https://github.com/circuitandchisel/auth/pull/103 are deployed 