### PR TITLE
Fix: Add missing Polygon network case in createDestinationMakers

### DIFF
--- a/packages/atxp-client/src/destinationMakers/index.ts
+++ b/packages/atxp-client/src/destinationMakers/index.ts
@@ -28,6 +28,9 @@ export function createDestinationMakers(config: DestinationMakerFactoryConfig): 
       case NetworkEnum.World:
         makers.set(network, new PassthroughDestinationMaker(network));
         break;
+      case NetworkEnum.Polygon:
+        makers.set(network, new PassthroughDestinationMaker(network));
+        break;
       case NetworkEnum.BaseSepolia:
         makers.set(network, new PassthroughDestinationMaker(network));
         break;


### PR DESCRIPTION
## Summary
- Adds the missing `NetworkEnum.Polygon` case in the `createDestinationMakers` switch statement
- The Polygon network was added to NetworkEnum in [ATXP-526](https://linear.app/circuitandchisel/issue/ATXP-526) Phase 1 Polygon commit but the switch statement wasn't updated
- This was causing a TypeScript error: "Argument of type 'NetworkEnum.Polygon' is not assignable to parameter of type 'never'"

## Related
- Linear issue: [ATXP-526](https://linear.app/circuitandchisel/issue/ATXP-526/phase-1-polygon-core-configuration-and-type-updates)
- Original PR: #98

## Test plan
- [x] Install dependencies with `npm install`
- [x] Build all packages with `npm run build`
- [x] Run typecheck with `npm run typecheck` - all checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)