### PR TITLE
Improve ATXPAccount error message for empty connection strings

### DIFF
--- a/packages/atxp-client/src/atxpAccount.test.ts
+++ b/packages/atxp-client/src/atxpAccount.test.ts
@@ -3,6 +3,41 @@ import { ATXPAccount } from '@atxp/common';
 import BigNumber from 'bignumber.js';
 
 describe('ATXPAccount', () => {
+  describe('constructor with invalid connection strings', () => {
+    it('should throw helpful error when connection string is empty string', () => {
+      expect(() => new ATXPAccount('')).toThrow('ATXPAccount: connection string is empty or not provided');
+    });
+
+    it('should throw helpful error when connection string is whitespace only', () => {
+      expect(() => new ATXPAccount('   ')).toThrow('ATXPAccount: connection string is empty or not provided');
+    });
+
+    it('should throw helpful error when connection string is undefined', () => {
+      expect(() => new ATXPAccount(undefined as any)).toThrow('ATXPAccount: connection string is empty or not provided');
+    });
+
+    it('should throw helpful error when connection string is null', () => {
+      expect(() => new ATXPAccount(null as any)).toThrow('ATXPAccount: connection string is empty or not provided');
+    });
+
+    it('should throw error when connection string is malformed URL', () => {
+      expect(() => new ATXPAccount('not-a-valid-url')).toThrow();
+    });
+
+    it('should throw error when connection string is missing connection_token', () => {
+      expect(() => new ATXPAccount('https://accounts.atxp.ai?account_id=acc_123')).toThrow(
+        'ATXPAccount: connection string missing connection token'
+      );
+    });
+
+    it('should throw error when connection string is missing account_id', () => {
+      expect(() => new ATXPAccount('https://accounts.atxp.ai?connection_token=test_token')).toThrow(
+        'ATXPAccount: connection string missing account id'
+      );
+    });
+  });
+
+
   describe('ATXPHttpPaymentMaker.getSourceAddress', () => {
     it('should call /address_for_payment endpoint and return sourceAddress', async () => {
       const mockFetch = vi.fn();

--- a/packages/atxp-common/src/atxpAccount.ts
+++ b/packages/atxp-common/src/atxpAccount.ts
@@ -9,6 +9,9 @@ function toBasicAuth(token: string): string {
 }
 
 function parseConnectionString(connectionString: string): { origin: string; token: string; accountId: string } {
+  if (!connectionString || connectionString.trim() === '') {
+    throw new Error('ATXPAccount: connection string is empty or not provided');
+  }
   const url = new URL(connectionString);
   const origin = url.origin;
   const token = url.searchParams.get('connection_token') || '';


### PR DESCRIPTION
## Summary
- Fixed unhelpful "Invalid URL" error message when empty/null/undefined connection strings are passed to ATXPAccount
- Added validation check that throws a clear error: "ATXPAccount: connection string is empty or not provided"
- Added comprehensive test coverage for various invalid connection string scenarios

## Changes
- Modified `parseConnectionString()` in `packages/atxp-common/src/atxpAccount.ts` to validate connection string before attempting to parse as URL
- Added 7 new test cases covering empty strings, whitespace, null, undefined, malformed URLs, and missing parameters

## Test plan
- [x] All existing tests pass
- [x] New tests verify proper error messages for:
  - Empty string
  - Whitespace-only string
  - `undefined` value
  - `null` value
  - Malformed URL
  - Missing `connection_token` parameter
  - Missing `account_id` parameter
- [x] Built `@atxp/common` package successfully
- [x] All 12 tests in atxpAccount.test.ts pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)