### PR TITLE
Add UI to dev:resource MCP server

### DIFF
--- a/src/dev/resource.ts
+++ b/src/dev/resource.ts
@@ -3,7 +3,7 @@ import express, { Request, Response } from 'express';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { z } from 'zod';
-import { CallToolResult } from '@modelcontextprotocol/sdk/types.js';
+import { CallToolResult, ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
 import { BigNumber } from 'bignumber.js';
 import { atxpExpress, atxpAccountId, requirePayment } from '@atxp/express';
 import { ConsoleLogger, LogLevel } from '@atxp/common';
@@ -12,30 +12,137 @@ import 'dotenv/config';
 
 const PORT = 3009;
 
+// MCP Apps UI resource key (from @modelcontextprotocol/ext-apps)
+const RESOURCE_URI_META_KEY = 'ui/resourceUri';
+
+// Simple test UI HTML - displays the message from tool result
+const SECURE_DATA_UI_HTML = `
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      overflow: hidden;
+      height: 180px;
+    }
+    body {
+      font-family: system-ui, -apple-system, sans-serif;
+      padding: 20px;
+      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+      color: white;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      box-sizing: border-box;
+    }
+    .container {
+      background: rgba(255,255,255,0.1);
+      border-radius: 12px;
+      padding: 24px;
+      backdrop-filter: blur(10px);
+      max-width: 400px;
+      text-align: center;
+    }
+    h2 { margin: 0 0 12px 0; font-size: 18px; }
+    .message { font-size: 16px; opacity: 0.9; }
+    .status { font-size: 12px; opacity: 0.7; margin-top: 12px; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h2>🔐 Secure Data UI</h2>
+    <div class="message" id="message">Waiting for data...</div>
+    <div class="status" id="status">Connecting...</div>
+  </div>
+  <script>
+    // Listen for tool result from host (MCP Apps spec)
+    window.addEventListener('message', (event) => {
+      console.log('[UI] Received message:', event.data);
+      const msg = event.data;
+
+      // Handle tool result notification (MCP Apps spec: ui/notifications/tool-result)
+      if (msg && msg.method === 'ui/notifications/tool-result') {
+        const result = msg.params;
+        document.getElementById('status').textContent = 'Data received!';
+
+        if (result.structuredContent) {
+          document.getElementById('message').textContent = result.structuredContent.message || 'No message';
+        } else if (result.content && result.content[0]) {
+          document.getElementById('message').textContent = result.content[0].text || 'No content';
+        }
+      }
+
+      // Handle tool input notification (MCP Apps spec: ui/notifications/tool-input)
+      if (msg && msg.method === 'ui/notifications/tool-input') {
+        document.getElementById('status').textContent = 'Processing...';
+        if (msg.params && msg.params.arguments) {
+          document.getElementById('message').textContent = 'Input: ' + (msg.params.arguments.message || 'none');
+        }
+      }
+    });
+
+    document.getElementById('status').textContent = 'Ready - waiting for tool result';
+  </script>
+</body>
+</html>
+`;
+
 const getServer = () => {
   // Create an MCP server with implementation details
   const server = new McpServer({
     name: 'stateless-streamable-http-server',
     version: '1.0.0',
-  }, { capabilities: { logging: {} } });
+  }, { capabilities: { logging: {}, resources: {} } });
+
+  // Register the UI resource for MCP Apps
+  server.resource(
+    'secure-data-ui',
+    'ui://secure-data',
+    {
+      description: 'UI template for the secure-data tool',
+      mimeType: 'text/html',
+    },
+    async (): Promise<ReadResourceResult> => ({
+      contents: [
+        {
+          uri: 'ui://secure-data',
+          mimeType: 'text/html',
+          text: SECURE_DATA_UI_HTML,
+        }
+      ],
+    })
+  );
 
   // Register a tool specifically for testing resumability
-  server.tool(
-    'secure-data',
-    'Secure data',
+  server.registerTool(
+    'secure_data',
     {
-      message: z.string().optional().describe('Message to secure'),
-    },
+      description: 'Secure data with UI display',
+      inputSchema: {
+        message: z.string().optional().describe('Message to secure'),
+      },
+      _meta: {
+        [RESOURCE_URI_META_KEY]: 'ui://secure-data',
+      },    },
     async ({ message }: { message?: string }): Promise<CallToolResult> => {
       const userId = atxpAccountId();
       await requirePayment({price: BigNumber(0.01)});
+      const responseMessage = `Secure data for user ${userId}: ${message || 'No message provided'}`;
       return {
         content: [
           {
             type: 'text',
-            text: `Secure data for user ${userId}: ${message || 'No message provided'}`,
+            text: responseMessage,
           }
         ],
+        structuredContent: {
+          message: responseMessage,
+          timestamp: new Date().toISOString(),
+        },
       };
     }
   );
@@ -54,7 +161,7 @@ const destination = new ATXPAccount(destinationConnectionString);
 console.log('Starting MCP server with destination', destinationConnectionString);
 app.use(atxpExpress({
   destination: destination,
-  server: 'https://auth.atxp.ai',
+  server: 'http://localhost:3010',
   payeeName: 'ATXP Client Example Resource Server',
   minimumPayment: BigNumber(0.01),
   allowHttp: true,


### PR DESCRIPTION
Updates our demo MCP server to server a UI in line with the [MCP Apps](https://blog.modelcontextprotocol.io/posts/2025-11-21-mcp-apps/) spec.

Replaces https://github.com/atxp-dev/sdk/pull/115