### PR TITLE
BREAKING: Make accountId async to support connection_token-only connection strings

### DIFF
--- a/examples/multichain/src/test-client.ts
+++ b/examples/multichain/src/test-client.ts
@@ -25,7 +25,7 @@ async function testBasePayment() {
 
   try {
     const account = new BaseAccount(baseRpc, basePrivateKey as `0x${string}`);
-    console.log('Using Base account:', account.accountId);
+    console.log('Using Base account:', await account.getAccountId());
 
     const mcpClient = await atxpClient({
       mcpServer: 'http://localhost:3009',
@@ -60,7 +60,7 @@ async function testSolanaPayment() {
 
   try {
     const account = new SolanaAccount(solanaEndpoint, solanaPrivateKey);
-    console.log('Using Solana account:', account.accountId);
+    console.log('Using Solana account:', await account.getAccountId());
 
     const mcpClient = await atxpClient({
       mcpServer: 'http://localhost:3009',
@@ -95,7 +95,7 @@ async function testPolygonPayment() {
 
   try {
     const account = new PolygonServerAccount(polygonRpc, polygonPrivateKey as `0x${string}`, 137);
-    console.log('Using Polygon account:', account.accountId);
+    console.log('Using Polygon account:', await account.getAccountId());
 
     const mcpClient = await atxpClient({
       mcpServer: 'http://localhost:3009',

--- a/packages/atxp-base/src/baseAccount.ts
+++ b/packages/atxp-base/src/baseAccount.ts
@@ -6,7 +6,7 @@ import { createWalletClient, http, WalletClient, LocalAccount } from 'viem';
 import { base } from 'viem/chains';
 
 export class BaseAccount implements Account {
-  accountId: AccountId;
+  private _accountId: AccountId;
   paymentMakers: PaymentMaker[];
   private walletClient: WalletClient;
   private account: PrivateKeyAccount;
@@ -22,7 +22,7 @@ export class BaseAccount implements Account {
     this.account = privateKeyToAccount(sourceSecretKey as Hex);
 
     // Format accountId as network:address
-    this.accountId = `base:${this.account.address}` as AccountId;
+    this._accountId = `base:${this.account.address}` as AccountId;
     this.walletClient = createWalletClient({
       account: this.account,
       chain: base,
@@ -31,6 +31,13 @@ export class BaseAccount implements Account {
     this.paymentMakers = [
       new BasePaymentMaker(baseRPCUrl, this.walletClient)
     ];
+  }
+
+  /**
+   * Get the account ID
+   */
+  async getAccountId(): Promise<AccountId> {
+    return this._accountId;
   }
 
   /**

--- a/packages/atxp-base/src/baseAppAccount.ephemeral.test.ts
+++ b/packages/atxp-base/src/baseAppAccount.ephemeral.test.ts
@@ -95,7 +95,7 @@ describe('BaseAppAccount', () => {
 
       // Verify account creation
       expect(account).toBeDefined();
-      expect(account.accountId).toBe(`base:${TEST_SMART_WALLET_ADDRESS}`);
+      expect(await account.getAccountId()).toBe(`base:${TEST_SMART_WALLET_ADDRESS}`);
       expect(account.paymentMakers).toBeDefined();
       expect(account.paymentMakers).toHaveLength(1);
       expect(account.paymentMakers[0]).toBeDefined();
@@ -160,7 +160,7 @@ describe('BaseAppAccount', () => {
 
       // Verify account was loaded from storage
       expect(account).toBeDefined();
-      expect(account.accountId).toBe(`base:${TEST_SMART_WALLET_ADDRESS}`);
+      expect(await account.getAccountId()).toBe(`base:${TEST_SMART_WALLET_ADDRESS}`);
 
       // Verify smart wallet was NOT deployed (reusing existing)
       expect(bundlerClient.sendUserOperation).not.toHaveBeenCalled();

--- a/packages/atxp-base/src/baseAppAccount.mainWallet.test.ts
+++ b/packages/atxp-base/src/baseAppAccount.mainWallet.test.ts
@@ -62,7 +62,7 @@ describe('BaseAppAccount - Main Wallet Mode', () => {
       });
 
       // Should have main wallet address as account ID (qualified with network)
-      expect(account.accountId).toBe(`base:${TEST_WALLET_ADDRESS}`);
+      expect(await account.getAccountId()).toBe(`base:${TEST_WALLET_ADDRESS}`);
 
       // Should have main wallet payment maker (first in array)
       expect(account.paymentMakers).toHaveLength(1);
@@ -105,7 +105,7 @@ describe('BaseAppAccount - Main Wallet Mode', () => {
         cache,
       });
 
-      expect(account.accountId).toBe(`base:${TEST_WALLET_ADDRESS}`);
+      expect(await account.getAccountId()).toBe(`base:${TEST_WALLET_ADDRESS}`);
       expect(account.paymentMakers).toHaveLength(1);
       expect(account.paymentMakers[0]).toBeInstanceOf(MainWalletPaymentMaker);
     });
@@ -181,7 +181,7 @@ describe('BaseAppAccount - Main Wallet Mode', () => {
       expect(account.paymentMakers).toHaveLength(1);
       expect(account.paymentMakers[0]).toBeDefined();
       // In ephemeral mode, we expect the account ID to be different from wallet address
-      expect(account.accountId).not.toBe(TEST_WALLET_ADDRESS);
+      expect(await account.getAccountId()).not.toBe(TEST_WALLET_ADDRESS);
     });
   });
 

--- a/packages/atxp-base/src/baseAppAccount.ts
+++ b/packages/atxp-base/src/baseAppAccount.ts
@@ -16,7 +16,7 @@ const DEFAULT_ALLOWANCE = 10n;
 const DEFAULT_PERIOD_IN_DAYS = 7;
 
 export class BaseAppAccount implements Account {
-  accountId: AccountId;
+  private _accountId: AccountId;
   paymentMakers: PaymentMaker[];
   private mainWalletAddress?: string;
   private ephemeralSmartWallet?: EphemeralSmartWallet;
@@ -154,7 +154,7 @@ export class BaseAppAccount implements Account {
         throw new Error('Spend permission is required for ephemeral wallet mode');
       }
       // Format accountId as network:address
-      this.accountId = `base:${ephemeralSmartWallet.address}` as AccountId;
+      this._accountId = `base:${ephemeralSmartWallet.address}` as AccountId;
       this.ephemeralSmartWallet = ephemeralSmartWallet;
       this.paymentMakers = [
         new BaseAppPaymentMaker(spendPermission, ephemeralSmartWallet, logger, chainId)
@@ -165,12 +165,19 @@ export class BaseAppAccount implements Account {
         throw new Error('Main wallet address and provider are required for main wallet mode');
       }
       // Format accountId as network:address
-      this.accountId = `base:${mainWalletAddress}` as AccountId;
+      this._accountId = `base:${mainWalletAddress}` as AccountId;
       this.mainWalletAddress = mainWalletAddress;
       this.paymentMakers = [
         new MainWalletPaymentMaker(mainWalletAddress, provider, logger, chainId)
       ];
     }
+  }
+
+  /**
+   * Get the account ID
+   */
+  async getAccountId(): Promise<AccountId> {
+    return this._accountId;
   }
 
   async getSources(): Promise<Source[]> {

--- a/packages/atxp-client/src/atxpClient.buildConfig.test.ts
+++ b/packages/atxp-client/src/atxpClient.buildConfig.test.ts
@@ -8,8 +8,9 @@ describe('buildConfig', () => {
       fetchFn,
       mcpServer: 'https://example.com/mcp',
       account: {
-        accountId: 'bdj',
-        paymentMakers: []
+        getAccountId: async () => 'bdj' as any,
+        paymentMakers: [],
+        getSources: async () => []
       }
     });
     expect(config.oAuthChannelFetch).toBe(fetchFn);

--- a/packages/atxp-client/src/atxpClient.events.test.ts
+++ b/packages/atxp-client/src/atxpClient.events.test.ts
@@ -28,13 +28,13 @@ describe('atxpClient events', () => {
       generateJWT: vi.fn().mockResolvedValue('testJWT')
     };
     const account = {
-      accountId: 'bdj',
+      getAccountId: vi.fn().mockResolvedValue('bdj'),
       paymentMakers: [paymentMaker],
       getSources: vi.fn().mockResolvedValue([])
     };
     const client = await atxpClient({
       mcpServer: 'https://example.com/mcp',
-      account, 
+      account,
       onAuthorize,
       fetchFn: f.fetchHandler
     });
@@ -43,7 +43,7 @@ describe('atxpClient events', () => {
     expect(res).toMatchObject({content: [{type: 'text', text: 'hello world'}]});
     expect(onAuthorize).toHaveBeenCalledWith({
       authorizationServer: DEFAULT_AUTHORIZATION_SERVER,
-      userId: account.accountId
+      userId: 'bdj'
     });
   });
 
@@ -68,27 +68,27 @@ describe('atxpClient events', () => {
       generateJWT: vi.fn().mockResolvedValue('testJWT')
     };
     const account = {
-      accountId: 'bdj',
+      getAccountId: vi.fn().mockResolvedValue('bdj'),
       paymentMakers: [paymentMaker],
       getSources: vi.fn().mockResolvedValue([])
     };
-    
+
     // The client initialization or callTool will throw an error due to OAuth failure
     await expect(async () => {
       const client = await atxpClient({
         mcpServer: 'https://example.com/mcp',
-        account, 
+        account,
         onAuthorizeFailure,
         fetchFn: f.fetchHandler
       });
       await client.callTool({ name: 'authorize', arguments: {} });
     }).rejects.toThrow('authorization response from the server is an error');
-    
+
     // The callback should have been called before the error was thrown
     expect(onAuthorizeFailure).toHaveBeenCalledTimes(1);
     expect(onAuthorizeFailure).toHaveBeenCalledWith({
       authorizationServer: DEFAULT_AUTHORIZATION_SERVER,
-      userId: account.accountId,
+      userId: 'bdj',
       error: expect.any(Error)
     });
   });
@@ -112,13 +112,13 @@ describe('atxpClient events', () => {
       generateJWT: vi.fn().mockResolvedValue('testJWT')
     };
     const account = {
-      accountId: 'bdj',
+      getAccountId: vi.fn().mockResolvedValue('bdj'),
       paymentMakers: [paymentMaker],
       getSources: vi.fn().mockResolvedValue([])
     };
     const client = await atxpClient({
       mcpServer: 'https://example.com/mcp',
-      account, 
+      account,
       onPayment,
       fetchFn: f.fetchHandler
     });
@@ -128,7 +128,7 @@ describe('atxpClient events', () => {
     expect(paymentMaker.makePayment).toHaveBeenCalled();
     expect(onPayment).toHaveBeenCalledWith({
       payment: expect.objectContaining({
-        accountId: account.accountId,
+        accountId: 'bdj',
         amount: BigNumber(0.01),
         currency: 'USDC'
       }),
@@ -158,26 +158,26 @@ describe('atxpClient events', () => {
       generateJWT: vi.fn().mockResolvedValue('testJWT')
     };
     const account = {
-      accountId: 'bdj',
+      getAccountId: vi.fn().mockResolvedValue('bdj'),
       paymentMakers: [paymentMaker],
       getSources: vi.fn().mockResolvedValue([])
     };
     const client = await atxpClient({
       mcpServer: 'https://example.com/mcp',
-      account, 
+      account,
       onPaymentFailure,
       fetchFn: f.fetchHandler
     });
 
     // The payment will fail and throw an error
     await expect(client.callTool({ name: 'pay', arguments: {} })).rejects.toThrow('Payment failed');
-    
+
     // Verify the callbacks were called
     expect(paymentMaker.makePayment).toHaveBeenCalledTimes(1);
     expect(onPaymentFailure).toHaveBeenCalledTimes(1);
     expect(onPaymentFailure).toHaveBeenCalledWith({
       payment: expect.objectContaining({
-        accountId: account.accountId,
+        accountId: 'bdj',
         amount: new BigNumber(0.01),
         currency: expect.any(String)
       }),

--- a/packages/atxp-client/src/atxpClient.test.ts
+++ b/packages/atxp-client/src/atxpClient.test.ts
@@ -27,13 +27,13 @@ describe('atxpClient', () => {
       generateJWT: vi.fn().mockResolvedValue('testJWT')
     };
     const account = {
-      accountId: 'bdj',
+      getAccountId: vi.fn().mockResolvedValue('bdj'),
       paymentMakers: [paymentMaker],
       getSources: vi.fn().mockResolvedValue([])
     };
     const client = await atxpClient({
       mcpServer: 'https://example.com/mcp',
-      account, 
+      account,
       fetchFn: f.fetchHandler
     });
 
@@ -64,13 +64,13 @@ describe('atxpClient', () => {
       generateJWT: vi.fn().mockResolvedValue('testJWT')
     };
     const account = {
-      accountId: 'bdj',
+      getAccountId: vi.fn().mockResolvedValue('bdj'),
       paymentMakers: [paymentMaker],
       getSources: vi.fn().mockResolvedValue([])
     };
     const client = await atxpClient({
       mcpServer: 'https://example.com/mcp',
-      account, 
+      account,
       fetchFn: f.fetchHandler
     });
 
@@ -114,7 +114,7 @@ describe('atxpClient', () => {
       generateJWT: vi.fn().mockResolvedValue('testJWT')
     };
     const account = {
-      accountId: 'bdj',
+      getAccountId: vi.fn().mockResolvedValue('bdj'),
       paymentMakers: [paymentMaker],
       getSources: vi.fn().mockResolvedValue([])
     };

--- a/packages/atxp-client/src/atxpFetcher.oauth.test.ts
+++ b/packages/atxp-client/src/atxpFetcher.oauth.test.ts
@@ -18,9 +18,9 @@ function mockPaymentMakers(solanaPaymentMaker?: PaymentMaker) {
 
 function atxpFetcher(fetchFn: FetchLike, paymentMakers?: PaymentMaker[], db?: OAuthDb) {
   const account: Account = {
-    accountId: "bdj" as any,
+    getAccountId: async () => "bdj" as any,
     paymentMakers: paymentMakers ?? mockPaymentMakers(),
-    getSources: () => [{
+    getSources: async () => [{
       address: 'SolAddress123',
       chain: 'solana' as any,
       walletType: 'eoa' as any

--- a/packages/atxp-client/src/atxpFetcher.payment.test.ts
+++ b/packages/atxp-client/src/atxpFetcher.payment.test.ts
@@ -30,9 +30,9 @@ function atxpFetcher(
   destinationMakers.set('solana', new PassthroughDestinationMaker('solana'));
 
   const account: Account = {
-    accountId: "bdj" as any,
+    getAccountId: async () => "bdj" as any,
     paymentMakers: paymentMakers ?? mockPaymentMakers(),
-    getSources: () => [{
+    getSources: async () => [{
       address: 'SolAddress123',
       chain: 'solana' as any,
       walletType: 'eoa' as any

--- a/packages/atxp-client/src/defaultPaymentFailureHandler.test.ts
+++ b/packages/atxp-client/src/defaultPaymentFailureHandler.test.ts
@@ -40,9 +40,9 @@ describe('Default Payment Failure Handler', () => {
 
     // Create an ATXPFetcher instance to access the default handler
     const account = {
-      accountId: 'test-account' as any,
+      getAccountId: async () => 'test-account' as any,
       paymentMakers: [],
-      getSources: () => []
+      getSources: async () => []
     };
 
     const fetcher = new ATXPFetcher({

--- a/packages/atxp-cloudflare/src/__tests__/atxpCloudflare.test.ts
+++ b/packages/atxp-cloudflare/src/__tests__/atxpCloudflare.test.ts
@@ -35,9 +35,9 @@ import { Account } from '@atxp/common';
 // Helper to create a mock Account for testing
 function mockAccount(accountId: string): Account {
   return {
-    accountId,
-    paymentMakers: {},
-    network: () => 'base'
+    getAccountId: async () => accountId as any,
+    paymentMakers: [],
+    getSources: async () => []
   };
 }
 

--- a/packages/atxp-cloudflare/src/__tests__/buildConfig.test.ts
+++ b/packages/atxp-cloudflare/src/__tests__/buildConfig.test.ts
@@ -15,9 +15,9 @@ vi.mock('@atxp/server', () => ({
 // Helper to create a mock Account for testing
 function mockAccount(accountId: string): Account {
   return {
-    accountId,
-    paymentMakers: {},
-    network: () => 'base'
+    getAccountId: async () => accountId as any,
+    paymentMakers: [],
+    getSources: async () => []
   };
 }
 

--- a/packages/atxp-cloudflare/src/__tests__/requirePayment.test.ts
+++ b/packages/atxp-cloudflare/src/__tests__/requirePayment.test.ts
@@ -25,9 +25,9 @@ import {
 // Helper to create a mock Account for testing
 function mockAccount(accountId: string): Account {
   return {
-    accountId,
-    paymentMakers: {},
-    network: () => 'base'
+    getAccountId: async () => accountId as any,
+    paymentMakers: [],
+    getSources: async () => []
   };
 }
 

--- a/packages/atxp-common/src/atxpAccount.ts
+++ b/packages/atxp-common/src/atxpAccount.ts
@@ -8,7 +8,7 @@ function toBasicAuth(token: string): string {
   return `Basic ${b64}`;
 }
 
-function parseConnectionString(connectionString: string): { origin: string; token: string; accountId: string } {
+function parseConnectionString(connectionString: string): { origin: string; token: string; accountId: string | null } {
   if (!connectionString || connectionString.trim() === '') {
     throw new Error('ATXPAccount: connection string is empty or not provided');
   }
@@ -19,9 +19,7 @@ function parseConnectionString(connectionString: string): { origin: string; toke
   if (!token) {
     throw new Error('ATXPAccount: connection string missing connection token');
   }
-  if (!accountId) {
-    throw new Error('ATXPAccount: connection string missing account id');
-  }
+  // accountId is now optional - will be fetched from /me endpoint if not provided
   return { origin, token, accountId };
 }
 
@@ -142,12 +140,13 @@ class ATXPHttpPaymentMaker implements PaymentMaker {
 }
 
 export class ATXPAccount implements Account {
-  accountId: AccountId;
   paymentMakers: PaymentMaker[];
   origin: string;
   token: string;
   fetchFn: FetchLike;
-  private unqualifiedAccountId: string;
+  private _cachedAccountId: AccountId | null = null;
+  private _unqualifiedAccountId: string | null = null;
+  private _accountIdPromise: Promise<AccountId> | null = null;
 
   constructor(connectionString: string, opts?: { fetchFn?: FetchLike; }) {
     const { origin, token, accountId } = parseConnectionString(connectionString);
@@ -158,21 +157,84 @@ export class ATXPAccount implements Account {
     this.token = token;
     this.fetchFn = fetchFn;
 
-    // Format accountId as network:address
-    // Connection string provides just the atxp_acct_xxx part (no prefix for UI)
-    this.unqualifiedAccountId = accountId;
-    this.accountId = `atxp:${accountId}` as AccountId;
+    // If accountId was provided in connection string, cache it immediately
+    if (accountId) {
+      this._unqualifiedAccountId = accountId;
+      this._cachedAccountId = `atxp:${accountId}` as AccountId;
+    }
+
     this.paymentMakers = [
       new ATXPHttpPaymentMaker(origin, token, fetchFn)
     ];
   }
 
   /**
+   * Get the account ID, fetching from /me endpoint if not provided in connection string.
+   * The result is cached after the first fetch.
+   */
+  async getAccountId(): Promise<AccountId> {
+    // Return cached value if available
+    if (this._cachedAccountId) {
+      return this._cachedAccountId;
+    }
+
+    // If already fetching, return the existing promise to avoid duplicate requests
+    if (this._accountIdPromise) {
+      return this._accountIdPromise;
+    }
+
+    // Fetch from /me endpoint
+    this._accountIdPromise = this.fetchAccountIdFromMe();
+    return this._accountIdPromise;
+  }
+
+  /**
+   * Fetch account ID from the /me endpoint using Bearer auth
+   */
+  private async fetchAccountIdFromMe(): Promise<AccountId> {
+    const response = await this.fetchFn(`${this.origin}/me`, {
+      method: 'GET',
+      headers: {
+        'Authorization': `Bearer ${this.token}`,
+        'Accept': 'application/json',
+      }
+    });
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(`ATXPAccount: /me failed: ${response.status} ${response.statusText} ${text}`);
+    }
+
+    const json = await response.json() as { account_id?: string };
+    if (!json?.account_id) {
+      throw new Error('ATXPAccount: /me did not return account_id');
+    }
+
+    // Cache the result
+    this._unqualifiedAccountId = json.account_id;
+    this._cachedAccountId = `atxp:${json.account_id}` as AccountId;
+    return this._cachedAccountId;
+  }
+
+  /**
+   * Get the unqualified account ID (without atxp: prefix), fetching if needed
+   */
+  private async getUnqualifiedAccountId(): Promise<string> {
+    if (this._unqualifiedAccountId) {
+      return this._unqualifiedAccountId;
+    }
+    // This will populate _unqualifiedAccountId as a side effect
+    await this.getAccountId();
+    return this._unqualifiedAccountId!;
+  }
+
+  /**
    * Get sources for this account by calling the accounts service
    */
   async getSources(): Promise<Source[]> {
-    // Use the unqualified account ID (without atxp: prefix) for the API call
-    const response = await this.fetchFn(`${this.origin}/account/${this.unqualifiedAccountId}/sources`, {
+    const unqualifiedAccountId = await this.getUnqualifiedAccountId();
+
+    const response = await this.fetchFn(`${this.origin}/account/${unqualifiedAccountId}/sources`, {
       method: 'GET',
       headers: {
         'Accept': 'application/json',
@@ -181,14 +243,14 @@ export class ATXPAccount implements Account {
 
     if (!response.ok) {
       const text = await response.text();
-      throw new Error(`ATXPAccount: /account/${this.unqualifiedAccountId}/sources failed: ${response.status} ${response.statusText} ${text}`);
+      throw new Error(`ATXPAccount: /account/${unqualifiedAccountId}/sources failed: ${response.status} ${response.statusText} ${text}`);
     }
 
     const json = await response.json() as Source[];
 
     // The accounts service returns the sources array directly, not wrapped in an object
     if (!Array.isArray(json)) {
-      throw new Error(`ATXPAccount: /account/${this.unqualifiedAccountId}/sources did not return sources array`);
+      throw new Error(`ATXPAccount: /account/${unqualifiedAccountId}/sources did not return sources array`);
     }
 
     return json;

--- a/packages/atxp-common/src/types.ts
+++ b/packages/atxp-common/src/types.ts
@@ -159,7 +159,7 @@ export interface DestinationMaker {
 }
 
 export type Account = {
-  accountId: AccountId;
+  getAccountId: () => Promise<AccountId>;
   paymentMakers: PaymentMaker[];
   getSources: () => Promise<Source[]>;
 }

--- a/packages/atxp-polygon/src/polygonBrowserAccount.ts
+++ b/packages/atxp-polygon/src/polygonBrowserAccount.ts
@@ -17,7 +17,7 @@ import { ConsoleLogger, Logger } from '@atxp/common';
  * does not provide Paymaster services for Polygon mainnet.
  */
 export class PolygonBrowserAccount implements Account {
-  accountId: AccountId;
+  private _accountId: AccountId;
   paymentMakers: PaymentMaker[];
   private walletAddress: string;
   private chainId: number;
@@ -78,11 +78,18 @@ export class PolygonBrowserAccount implements Account {
     this.chainId = chainId;
 
     // Format accountId as network:address
-    this.accountId = `polygon:${walletAddress}` as AccountId;
+    this._accountId = `polygon:${walletAddress}` as AccountId;
 
     this.paymentMakers = [
       new DirectWalletPaymentMaker(walletAddress, provider, logger, chainId)
     ];
+  }
+
+  /**
+   * Get the account ID
+   */
+  async getAccountId(): Promise<AccountId> {
+    return this._accountId;
   }
 
   async getSources(): Promise<Source[]> {

--- a/packages/atxp-polygon/src/polygonServerAccount.ts
+++ b/packages/atxp-polygon/src/polygonServerAccount.ts
@@ -27,7 +27,7 @@ import type { Chain } from 'viem/chains';
  * ```
  */
 export class PolygonServerAccount implements Account {
-  accountId: AccountId;
+  private _accountId: AccountId;
   paymentMakers: PaymentMaker[];
   private walletClient: WalletClient;
   private account: PrivateKeyAccount;
@@ -49,7 +49,7 @@ export class PolygonServerAccount implements Account {
 
     // Determine network name for accountId
     const networkName = chainId === 137 ? 'polygon' : 'polygon_amoy';
-    this.accountId = `${networkName}:${this.account.address}` as AccountId;
+    this._accountId = `${networkName}:${this.account.address}` as AccountId;
 
     // Get the appropriate chain configuration
     const chain = this.getChain(chainId);
@@ -63,6 +63,13 @@ export class PolygonServerAccount implements Account {
     this.paymentMakers = [
       new ServerPaymentMaker(polygonRPCUrl, this.walletClient, chainId)
     ];
+  }
+
+  /**
+   * Get the account ID
+   */
+  async getAccountId(): Promise<AccountId> {
+    return this._accountId;
   }
 
   private getChain(chainId: number): Chain {

--- a/packages/atxp-server/src/requirePayment.ts
+++ b/packages/atxp-server/src/requirePayment.ts
@@ -18,7 +18,7 @@ export async function requirePayment(paymentConfig: RequirePaymentConfig): Promi
     : paymentConfig.price;
 
   // Get network and address from destination Account
-  const destinationAccountId = config.destination.accountId;
+  const destinationAccountId = await config.destination.getAccountId();
   const destinationNetwork = extractNetworkFromAccountId(destinationAccountId);
   const destinationAddress = extractAddressFromAccountId(destinationAccountId);
 

--- a/packages/atxp-server/src/serverConfig.test.ts
+++ b/packages/atxp-server/src/serverConfig.test.ts
@@ -6,7 +6,7 @@ import type { Account } from '@atxp/common';
 // Helper to create a mock Account for testing
 function mockAccount(accountId: string): Account {
   return {
-    accountId: `base:${accountId}` as any,
+    getAccountId: async () => `base:${accountId}` as any,
     paymentMakers: [],
     getSources: async () => [],
   };

--- a/packages/atxp-server/src/serverTestHelpers.ts
+++ b/packages/atxp-server/src/serverTestHelpers.ts
@@ -16,8 +16,9 @@ export const SOURCE = 'testSource';
 
 // Helper to create a mock Account for testing
 export function mockAccount(accountId: string): Account {
+  const formattedAccountId = `base:${accountId}`;
   return {
-    accountId: `base:${accountId}` as any, // Format as base:address for tests
+    getAccountId: async () => formattedAccountId as any,
     paymentMakers: [],
     getSources: async () => [],
   };

--- a/packages/atxp-solana/src/solanaAccount.ts
+++ b/packages/atxp-solana/src/solanaAccount.ts
@@ -5,7 +5,7 @@ import { Keypair } from "@solana/web3.js";
 import bs58 from "bs58";
 
 export class SolanaAccount implements Account {
-  accountId: AccountId;
+  private _accountId: AccountId;
   paymentMakers: PaymentMaker[];
   private sourcePublicKey: string;
 
@@ -20,10 +20,17 @@ export class SolanaAccount implements Account {
     this.sourcePublicKey = source.publicKey.toBase58();
 
     // Format accountId as network:address
-    this.accountId = `solana:${this.sourcePublicKey}` as AccountId;
+    this._accountId = `solana:${this.sourcePublicKey}` as AccountId;
     this.paymentMakers = [
       new SolanaPaymentMaker(solanaEndpoint, sourceSecretKey)
     ];
+  }
+
+  /**
+   * Get the account ID
+   */
+  async getAccountId(): Promise<AccountId> {
+    return this._accountId;
   }
 
   /**

--- a/packages/atxp-worldchain/src/worldchainAccount.ephemeral.test.ts
+++ b/packages/atxp-worldchain/src/worldchainAccount.ephemeral.test.ts
@@ -95,7 +95,7 @@ describe('WorldchainAccount', () => {
 
       // Verify account creation
       expect(account).toBeDefined();
-      expect(account.accountId).toBe(`world:${TEST_SMART_WALLET_ADDRESS}`);
+      expect(await account.getAccountId()).toBe(`world:${TEST_SMART_WALLET_ADDRESS}`);
       expect(account.paymentMakers).toBeDefined();
       expect(account.paymentMakers[0]).toBeDefined();
 
@@ -159,7 +159,7 @@ describe('WorldchainAccount', () => {
 
       // Verify account was loaded from storage
       expect(account).toBeDefined();
-      expect(account.accountId).toBe(`world:${TEST_SMART_WALLET_ADDRESS}`);
+      expect(await account.getAccountId()).toBe(`world:${TEST_SMART_WALLET_ADDRESS}`);
 
       // Verify smart wallet was NOT deployed (reusing existing)
       expect(bundlerClient.sendUserOperation).not.toHaveBeenCalled();

--- a/packages/atxp-worldchain/src/worldchainAccount.mainWallet.test.ts
+++ b/packages/atxp-worldchain/src/worldchainAccount.mainWallet.test.ts
@@ -68,7 +68,7 @@ describe('WorldchainAccount - Main Wallet Mode', () => {
 
       // Verify account creation
       expect(account).toBeDefined();
-      expect(account.accountId).toBe(`world:${TEST_WALLET_ADDRESS}`); // Uses main wallet address as account ID (qualified with network)
+      expect(await account.getAccountId()).toBe(`world:${TEST_WALLET_ADDRESS}`); // Uses main wallet address as account ID (qualified with network)
       expect(account.paymentMakers).toBeDefined();
       expect(account.paymentMakers[0]).toBeDefined();
 
@@ -100,7 +100,7 @@ describe('WorldchainAccount - Main Wallet Mode', () => {
 
       // Verify account was created with correct payment maker
       expect(account).toBeDefined();
-      expect(account.accountId).toBe(`world:${TEST_WALLET_ADDRESS}`);
+      expect(await account.getAccountId()).toBe(`world:${TEST_WALLET_ADDRESS}`);
       expect(account.paymentMakers[0]).toBeDefined();
     });
 
@@ -124,7 +124,7 @@ describe('WorldchainAccount - Main Wallet Mode', () => {
 
       // Verify initialization succeeded despite wallet_connect failure
       expect(account).toBeDefined();
-      expect(account.accountId).toBe(`world:${TEST_WALLET_ADDRESS}`);
+      expect(await account.getAccountId()).toBe(`world:${TEST_WALLET_ADDRESS}`);
       expect(provider.request).toHaveBeenCalledWith({ method: 'wallet_connect' });
     });
 

--- a/packages/atxp-worldchain/src/worldchainAccount.ts
+++ b/packages/atxp-worldchain/src/worldchainAccount.ts
@@ -18,7 +18,7 @@ const DEFAULT_ALLOWANCE = 10n;
 const DEFAULT_PERIOD_IN_DAYS = 7;
 
 export class WorldchainAccount implements Account {
-  accountId: AccountId;
+  private _accountId: AccountId;
   paymentMakers: PaymentMaker[];
   private mainWalletAddress?: string;
   private ephemeralSmartWallet?: EphemeralSmartWallet;
@@ -159,7 +159,7 @@ export class WorldchainAccount implements Account {
         throw new Error('Spend permission is required for ephemeral wallet mode');
       }
       // Format accountId as network:address
-      this.accountId = `world:${ephemeralSmartWallet.address}` as AccountId;
+      this._accountId = `world:${ephemeralSmartWallet.address}` as AccountId;
       this.ephemeralSmartWallet = ephemeralSmartWallet;
       this.paymentMakers = [
         new WorldchainPaymentMaker(spendPermission, ephemeralSmartWallet, {
@@ -174,12 +174,19 @@ export class WorldchainAccount implements Account {
         throw new Error('Main wallet address and provider are required for main wallet mode');
       }
       // Format accountId as network:address
-      this.accountId = `world:${mainWalletAddress}` as AccountId;
+      this._accountId = `world:${mainWalletAddress}` as AccountId;
       this.mainWalletAddress = mainWalletAddress;
       this.paymentMakers = [
         new MainWalletPaymentMaker(mainWalletAddress, provider, logger, chainId, customRpcUrl)
       ];
     }
+  }
+
+  /**
+   * Get the account ID
+   */
+  async getAccountId(): Promise<AccountId> {
+    return this._accountId;
   }
 
   async getSources(): Promise<Source[]> {

--- a/packages/atxp-x402/src/x402Wrapper.ts
+++ b/packages/atxp-x402/src/x402Wrapper.ts
@@ -118,8 +118,9 @@ export const wrapWithX402: FetchWrapper = (config: ClientArgs): FetchLike => {
 
       // Create the ProspectivePayment object for callbacks
       const url = typeof input === 'string' ? input : input.toString();
+      const accountId = await account.getAccountId();
       const prospectivePayment: ProspectivePayment = {
-        accountId: account.accountId,
+        accountId,
         resourceUrl: url,
         resourceName: selectedPaymentRequirements.description || url,
         currency: 'USDC',
@@ -270,13 +271,13 @@ export const wrapWithX402: FetchWrapper = (config: ClientArgs): FetchLike => {
         const firstOption = paymentChallenge.accepts[0] as { maxAmountRequired?: string | number; description?: string; network?: string; payTo?: string };
         const amount = firstOption.maxAmountRequired ? Number(firstOption.maxAmountRequired) / (10 ** 6) : 0;
         const url = typeof input === 'string' ? input : input.toString();
+        const accountId = await account.getAccountId();
         const errorNetwork = firstOption.network || 'unknown';
         const typedError = error as Error;
         const isRetryable = typedError instanceof ATXPPaymentError ? typedError.retryable : true;
-
         await onPaymentFailure({
           payment: {
-            accountId: account.accountId,
+            accountId,
             resourceUrl: url,
             resourceName: firstOption.description || url,
             currency: 'USDC',


### PR DESCRIPTION
## Summary

**This is a BREAKING CHANGE to the public API.**

- Changed Account interface from `accountId: AccountId` to `getAccountId(): Promise<AccountId>`
- ATXPAccount now supports connection strings with only `connection_token` (without `account_id`)
- When `account_id` is missing, ATXPAccount fetches it from the `/me` endpoint using Bearer auth
- Lazy initialization pattern: accountId is fetched on first access and cached

### Changed Files

**Core Types:**
- `packages/atxp-common/src/types.ts` - Account interface
- `packages/atxp-common/src/atxpAccount.ts` - /me endpoint fetch

**Account Implementations:**
- `packages/atxp-base/src/baseAccount.ts`
- `packages/atxp-base/src/baseAppAccount.ts`
- `packages/atxp-polygon/src/polygonBrowserAccount.ts`
- `packages/atxp-polygon/src/polygonServerAccount.ts`
- `packages/atxp-solana/src/solanaAccount.ts`
- `packages/atxp-worldchain/src/worldchainAccount.ts`

**Client/Server:**
- `packages/atxp-client/src/atxpFetcher.ts` - Lazy OAuthClient init
- `packages/atxp-server/src/requirePayment.ts`
- `packages/atxp-x402/src/x402Wrapper.ts`

### Migration Guide

Replace:
```typescript
const id = account.accountId;
```

With:
```typescript
const id = await account.getAccountId();
```

For mock accounts in tests, replace:
```typescript
{ accountId: 'test-id', paymentMakers: [], getSources: async () => [] }
```

With:
```typescript
{ getAccountId: async () => 'test-id', paymentMakers: [], getSources: async () => [] }
```

## Test plan

- [x] Build succeeds
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)