### PR TITLE
Fix /me endpoint to expect accountId (camelCase)

### DIFF
--- a/packages/atxp-client/src/atxpAccount.test.ts
+++ b/packages/atxp-client/src/atxpAccount.test.ts
@@ -34,13 +34,13 @@ describe('ATXPAccount', () => {
       const mockFetch = vi.fn();
       mockFetch.mockResolvedValueOnce({
         ok: true,
-        json: async () => ({ account_id: 'fetched-account-123' })  // Raw account_id without atxp: prefix
+        json: async () => ({ accountId: 'fetched-account-123' })  // Raw accountId without atxp: prefix
       });
 
       // Should NOT throw on construction
       const account = new ATXPAccount('https://accounts.atxp.ai?connection_token=test_token', { fetchFn: mockFetch });
 
-      // Should fetch account_id from /me endpoint when getAccountId() is called
+      // Should fetch accountId from /me endpoint when getAccountId() is called
       // The returned value will have atxp: prefix added by the implementation
       const accountId = await account.getAccountId();
       expect(accountId).toBe('atxp:fetched-account-123');

--- a/packages/atxp-common/src/atxpAccount.ts
+++ b/packages/atxp-common/src/atxpAccount.ts
@@ -205,14 +205,14 @@ export class ATXPAccount implements Account {
       throw new Error(`ATXPAccount: /me failed: ${response.status} ${response.statusText} ${text}`);
     }
 
-    const json = await response.json() as { account_id?: string };
-    if (!json?.account_id) {
-      throw new Error('ATXPAccount: /me did not return account_id');
+    const json = await response.json() as { accountId?: string };
+    if (!json?.accountId) {
+      throw new Error('ATXPAccount: /me did not return accountId');
     }
 
     // Cache the result
-    this._unqualifiedAccountId = json.account_id;
-    this._cachedAccountId = `atxp:${json.account_id}` as AccountId;
+    this._unqualifiedAccountId = json.accountId;
+    this._cachedAccountId = `atxp:${json.accountId}` as AccountId;
     return this._cachedAccountId;
   }
 


### PR DESCRIPTION
## Summary
- Fix getAccountId() to expect `accountId` from /me endpoint instead of `account_id`
- The accounts server returns camelCase but SDK was expecting snake_case

## Test plan
- [x] All 240 SDK tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)