### PR TITLE
Add PaymentDestination interface for lightweight server destinations

### DIFF
--- a/packages/atxp-common/src/accountIdDestination.ts
+++ b/packages/atxp-common/src/accountIdDestination.ts
@@ -1,0 +1,73 @@
+import type { PaymentDestination, AccountId, Source, FetchLike } from './types.js';
+import { DEFAULT_ATXP_ACCOUNTS_SERVER } from './types.js';
+
+/**
+ * A lightweight PaymentDestination implementation that only requires an account ID.
+ *
+ * Use this when you need a destination for server middleware but don't have
+ * (or need) a full connection string with connection_token. This is useful for
+ * sprites and other services that receive payments but don't need to make payments.
+ *
+ * The account ID can be either:
+ * - A fully qualified ID (e.g., "atxp:abc123")
+ * - An unqualified ID (e.g., "abc123") which will be prefixed with "atxp:"
+ */
+export class AccountIdDestination implements PaymentDestination {
+  private accountId: AccountId;
+  private unqualifiedAccountId: string;
+  private accountsBaseUrl: string;
+  private fetchFn: FetchLike;
+
+  constructor(
+    accountId: string,
+    opts?: {
+      accountsBaseUrl?: string;
+      fetchFn?: FetchLike;
+    }
+  ) {
+    // Handle both qualified (atxp:abc123) and unqualified (abc123) account IDs
+    if (accountId.includes(':')) {
+      this.accountId = accountId as AccountId;
+      this.unqualifiedAccountId = accountId.split(':')[1];
+    } else {
+      this.accountId = `atxp:${accountId}` as AccountId;
+      this.unqualifiedAccountId = accountId;
+    }
+
+    this.accountsBaseUrl = opts?.accountsBaseUrl ?? DEFAULT_ATXP_ACCOUNTS_SERVER;
+    this.fetchFn = opts?.fetchFn ?? fetch;
+  }
+
+  async getAccountId(): Promise<AccountId> {
+    return this.accountId;
+  }
+
+  async getSources(): Promise<Source[]> {
+    const response = await this.fetchFn(
+      `${this.accountsBaseUrl}/account/${this.unqualifiedAccountId}/sources`,
+      {
+        method: 'GET',
+        headers: {
+          'Accept': 'application/json',
+        },
+      }
+    );
+
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(
+        `AccountIdDestination: /account/${this.unqualifiedAccountId}/sources failed: ${response.status} ${response.statusText} ${text}`
+      );
+    }
+
+    const json = await response.json() as Source[];
+
+    if (!Array.isArray(json)) {
+      throw new Error(
+        `AccountIdDestination: /account/${this.unqualifiedAccountId}/sources did not return sources array`
+      );
+    }
+
+    return json;
+  }
+}

--- a/packages/atxp-common/src/index.ts
+++ b/packages/atxp-common/src/index.ts
@@ -68,6 +68,7 @@ export {
   type PaymentIdentifier,
   type PaymentMaker,
   type DestinationMaker,
+  type PaymentDestination,
   type Account,
   type Source,
   extractAddressFromAccountId,
@@ -133,3 +134,8 @@ export {
 export {
   ATXPAccount
 } from './atxpAccount.js';
+
+// Lightweight destination implementation (no connection_token required)
+export {
+  AccountIdDestination
+} from './accountIdDestination.js';

--- a/packages/atxp-common/src/types.ts
+++ b/packages/atxp-common/src/types.ts
@@ -158,10 +158,22 @@ export interface DestinationMaker {
   makeDestinations: (option: PaymentRequestOption, logger: Logger, paymentRequestId: string, sources: Source[]) => Promise<Destination[]>;
 }
 
-export type Account = {
+/**
+ * Minimal interface for payment destinations.
+ * Used by server middleware to identify where payments should be sent.
+ * Does not require the ability to make payments (no paymentMakers needed).
+ */
+export interface PaymentDestination {
   getAccountId: () => Promise<AccountId>;
-  paymentMakers: PaymentMaker[];
   getSources: () => Promise<Source[]>;
+}
+
+/**
+ * Full account interface that can both receive and make payments.
+ * Extends PaymentDestination so any Account can be used as a destination.
+ */
+export type Account = PaymentDestination & {
+  paymentMakers: PaymentMaker[];
 }
 
 /**

--- a/packages/atxp-server/src/types.ts
+++ b/packages/atxp-server/src/types.ts
@@ -1,4 +1,4 @@
-import { AuthorizationServerUrl, Currency, Logger, PaymentRequest, UrlString, OAuthDb, TokenData, OAuthResourceClient, Account } from "@atxp/common";
+import { AuthorizationServerUrl, Currency, Logger, PaymentRequest, UrlString, OAuthDb, TokenData, OAuthResourceClient, PaymentDestination } from "@atxp/common";
 import { BigNumber } from "bignumber.js";
 
 // https://github.com/modelcontextprotocol/typescript-sdk/blob/c6ac083b1b37b222b5bfba5563822daa5d03372e/src/types.ts
@@ -52,7 +52,7 @@ export type PaymentServer = {
 }
 
 export type ATXPConfig = {
-  destination: Account;
+  destination: PaymentDestination;
   mountPath: string;
   currency: Currency;
   server: AuthorizationServerUrl;


### PR DESCRIPTION
## Summary

- Adds `PaymentDestination` interface to `@atxp/common` - minimal interface for server destinations
- Updates `Account` type to extend `PaymentDestination` (backwards compatible)
- Adds `AccountIdDestination` class - lightweight destination using just an accountId
- Updates server `ATXPConfig.destination` type from `Account` to `PaymentDestination`

## Motivation

Sprites and other services that receive payments don't need a full connection_token to operate. They only need:
- `getAccountId()` - to identify where payments go
- `getSources()` - to provide payment options (public endpoint, no auth)

This change allows servers to use:
```typescript
import { AccountIdDestination } from '@atxp/common';
const destination = new AccountIdDestination('abc123');
```

Instead of requiring a full connection string:
```typescript
import { ATXPAccount } from '@atxp/common';
const destination = new ATXPAccount(process.env.ATXP_CONNECTION_STRING!);
```

## Changes

**New interface** (`types.ts`):
```typescript
export interface PaymentDestination {
  getAccountId: () => Promise<AccountId>;
  getSources: () => Promise<Source[]>;
}
```

**Updated Account** (`types.ts`):
```typescript
export type Account = PaymentDestination & {
  paymentMakers: PaymentMaker[];
}
```

**New class** (`accountIdDestination.ts`):
- Takes accountId string (qualified `atxp:abc123` or unqualified `abc123`)
- Calls public `/account/{id}/sources` endpoint (no auth needed)
- No connection_token required

## Test plan

- [x] All existing tests pass
- [x] Manual test with sprite using `AccountIdDestination`

🤖 Generated with [Claude Code](https://claude.com/claude-code)