### PR TITLE
feat: Handle 202 Accepted from /charge endpoint

### DIFF
--- a/packages/atxp-server/src/paymentServer.ts
+++ b/packages/atxp-server/src/paymentServer.ts
@@ -42,7 +42,8 @@ export class ATXPPaymentServer implements PaymentServer {
 
   charge = async(chargeRequest: Charge): Promise<boolean> => {
     const chargeResponse = await this.makeRequest('POST', '/charge', chargeRequest);
-    if (chargeResponse.status === 200) {
+    // 200 = synchronous success, 202 = accepted (async payment in progress)
+    if (chargeResponse.status === 200 || chargeResponse.status === 202) {
       return true;
     } else if (chargeResponse.status === 402) {
       return false;


### PR DESCRIPTION
## Summary
- Added support for HTTP 202 (Accepted) responses from the `/charge` endpoint
- The auth service now returns 202 for async payments that are accepted but still processing
- This treats 202 the same as 200 (success) from the SDK's perspective

## Changes
- `paymentServer.ts`: Added 202 to the accepted status codes for charge success
- `paymentServer.test.ts`: Added test for 202 response handling

## Response codes:
- **200**: Synchronous payment completed
- **202**: Async payment accepted (balance checked, executing in background)
- **402**: Insufficient balance

## Test plan
- [x] Added unit test for 202 response handling
- [ ] Integration test with auth service returning 202

🤖 Generated with [Claude Code](https://claude.com/claude-code)