### PR TITLE
fix(express,cloudflare): move @atxp/server to peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15803,6 +15803,7 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.30.tgz",
       "integrity": "sha512-6q+aFfKL0SpT8prfdpR3V8HcN51ov0mCGuwQTzyuk6eeO9rg7a7LWbgPv9rEVXGZEuyULstL8LGNwHqusand7Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.20",
@@ -21506,6 +21507,7 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.83.1.tgz",
       "integrity": "sha512-mL1q5HPq5cWseVhWRLl+Fwvi5z1UO+3vGOpjr+sHFwcUletPRZ5Kv+d0tUfqHmvi73/53NjlQqX1Pyn4GguUfA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.83.1",
@@ -21563,8 +21565,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/react-native-url-polyfill/-/react-native-url-polyfill-3.0.0.tgz",
       "integrity": "sha512-aA5CiuUCUb/lbrliVCJ6lZ17/RpNJzvTO/C7gC/YmDQhTUoRD5q5HlJfwLWcxz4VgAhHwXKzhxH+wUN24tAdqg==",
+      "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "whatwg-url-without-unicode": "8.0.0-3"
       },
@@ -25195,35 +25197,6 @@
         "vitest": "^4.0.16"
       }
     },
-    "packages/atxp-base/node_modules/@atxp/client": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@atxp/client/-/client-0.10.6.tgz",
-      "integrity": "sha512-B6FJTaj9q2C7Dj3Mi5IAvu39S1n4Add7ISWZGvCz/uIt/zato0uKUx5gXrRNH1W3wTnlVSsz1rWqVKZ8zt8Z+g==",
-      "license": "MIT",
-      "dependencies": {
-        "@atxp/common": "0.10.6",
-        "@modelcontextprotocol/sdk": "^1.15.0",
-        "bignumber.js": "^9.3.0",
-        "oauth4webapi": "^3.8.3"
-      },
-      "peerDependencies": {
-        "expo-crypto": ">=14.0.0",
-        "react-native-url-polyfill": "^3.0.0"
-      }
-    },
-    "packages/atxp-base/node_modules/@atxp/common": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@atxp/common/-/common-0.10.6.tgz",
-      "integrity": "sha512-TgsDG2NjQjfyBoQkKw6QIkCTnC+GhMB5tBHLffmFcOhyaPTPdpzDmSTiodydtTRRgZGqrRygS6yDsovD0Iy3zg==",
-      "license": "MIT",
-      "dependencies": {
-        "bignumber.js": "^9.3.0",
-        "jose": "^6.0.11",
-        "oauth4webapi": "^3.8.3",
-        "tweetnacl": "^1.0.3",
-        "tweetnacl-util": "^0.15.1"
-      }
-    },
     "packages/atxp-client": {
       "name": "@atxp/client",
       "version": "0.10.7",
@@ -25253,26 +25226,12 @@
         "react-native-url-polyfill": "^3.0.0"
       }
     },
-    "packages/atxp-client/node_modules/@atxp/common": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@atxp/common/-/common-0.10.6.tgz",
-      "integrity": "sha512-TgsDG2NjQjfyBoQkKw6QIkCTnC+GhMB5tBHLffmFcOhyaPTPdpzDmSTiodydtTRRgZGqrRygS6yDsovD0Iy3zg==",
-      "license": "MIT",
-      "dependencies": {
-        "bignumber.js": "^9.3.0",
-        "jose": "^6.0.11",
-        "oauth4webapi": "^3.8.3",
-        "tweetnacl": "^1.0.3",
-        "tweetnacl-util": "^0.15.1"
-      }
-    },
     "packages/atxp-cloudflare": {
       "name": "@atxp/cloudflare",
-      "version": "0.10.7",
+      "version": "0.10.8",
       "license": "MIT",
       "dependencies": {
-        "@atxp/common": "0.10.7",
-        "@atxp/server": "0.10.7"
+        "@atxp/common": "0.10.7"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20241022.0",
@@ -25286,6 +25245,7 @@
         "vitest": "^4.0.16"
       },
       "peerDependencies": {
+        "@atxp/server": "^0.10.7",
         "agents": "^0.3.3"
       }
     },
@@ -25312,11 +25272,8 @@
     },
     "packages/atxp-express": {
       "name": "@atxp/express",
-      "version": "0.10.7",
+      "version": "0.10.8",
       "license": "MIT",
-      "dependencies": {
-        "@atxp/server": "0.10.7"
-      },
       "devDependencies": {
         "@types/express": "^5.0.0",
         "@types/node": "^25.0.3",
@@ -25330,20 +25287,8 @@
         "vitest": "^4.0.16"
       },
       "peerDependencies": {
+        "@atxp/server": "^0.10.7",
         "express": "^5.0.0"
-      }
-    },
-    "packages/atxp-express/node_modules/@atxp/common": {
-      "version": "0.10.6",
-      "resolved": "https://registry.npmjs.org/@atxp/common/-/common-0.10.6.tgz",
-      "integrity": "sha512-TgsDG2NjQjfyBoQkKw6QIkCTnC+GhMB5tBHLffmFcOhyaPTPdpzDmSTiodydtTRRgZGqrRygS6yDsovD0Iy3zg==",
-      "license": "MIT",
-      "dependencies": {
-        "bignumber.js": "^9.3.0",
-        "jose": "^6.0.11",
-        "oauth4webapi": "^3.8.3",
-        "tweetnacl": "^1.0.3",
-        "tweetnacl-util": "^0.15.1"
       }
     },
     "packages/atxp-polygon": {
@@ -25392,6 +25337,7 @@
       "name": "@atxp/server",
       "version": "0.10.7",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@atxp/common": "0.10.7",
         "@modelcontextprotocol/sdk": "^1.15.0",

--- a/packages/atxp-cloudflare/package.json
+++ b/packages/atxp-cloudflare/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atxp/cloudflare",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "ATXP Cloudflare - Cloudflare Workers integration for Authorization Token Exchange Protocol",
   "license": "MIT",
   "repository": {
@@ -33,11 +33,11 @@
     "pack:dry": "npm pack --dry-run"
   },
   "dependencies": {
-    "@atxp/common": "0.10.7",
-    "@atxp/server": "0.10.7"
+    "@atxp/common": "0.10.7"
   },
   "peerDependencies": {
-    "agents": "^0.3.3"
+    "agents": "^0.3.3",
+    "@atxp/server": "^0.10.7"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20241022.0",

--- a/packages/atxp-express/package.json
+++ b/packages/atxp-express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atxp/express",
-  "version": "0.10.7",
+  "version": "0.10.8",
   "description": "ATXP Express - Express.js integration for Authorization Token Exchange Protocol",
   "license": "MIT",
   "repository": {
@@ -32,11 +32,10 @@
     "prepack": "npm run build && npm run typecheck",
     "pack:dry": "npm pack --dry-run"
   },
-  "dependencies": {
-    "@atxp/server": "0.10.7"
-  },
+  "dependencies": {},
   "peerDependencies": {
-    "express": "^5.0.0"
+    "express": "^5.0.0",
+    "@atxp/server": "^0.10.7"
   },
   "devDependencies": {
     "@types/express": "^5.0.0",


### PR DESCRIPTION
## Problem

`@atxp/express` bundles `@atxp/server` as a regular dependency. When a consumer also depends on `@atxp/server` directly, npm installs two copies with separate module-level state — the ATXP context set by express is invisible to the consumer's imports.

## Fix

Move `@atxp/server` from `dependencies` to `peerDependencies` in `@atxp/express` and `@atxp/cloudflare`. Bump both to `0.10.8`.

## Migration

Consumers need to add `@atxp/server` as a direct dependency:
```bash
npm install @atxp/server@^0.10.7
```

Linear-issue: ATXP-1712