### PR TITLE
fix: unify PaymentProtocol type (use @atxp/common, not local duplicate)

### DIFF
--- a/packages/atxp-server/src/protocol.ts
+++ b/packages/atxp-server/src/protocol.ts
@@ -1,11 +1,6 @@
-import { AuthorizationServerUrl, FetchLike, Logger } from "@atxp/common";
-
-/**
- * Payment protocol types supported by the omni-challenge system.
- * - 'atxp': ATXP-MCP protocol (JWT-based, existing flow)
- * - 'x402': X402 protocol (Permit2 / X-PAYMENT header)
- */
-export type PaymentProtocol = 'atxp' | 'x402';
+import { AuthorizationServerUrl, FetchLike, Logger, type PaymentProtocol } from "@atxp/common";
+// Re-export from common so consumers of @atxp/server get the same type
+export type { PaymentProtocol } from "@atxp/common";
 
 /**
  * Result of detecting which protocol a client used from its credential.


### PR DESCRIPTION
@atxp/server had its own `PaymentProtocol = 'atxp' | 'x402'` which didn't include `'mpp'`. This caused type errors when passing `PaymentProtocol` from `@atxp/common` (which includes all protocols) to `ProtocolSettlement.settle()`.

Now imports and re-exports from `@atxp/common` for type consistency.

Blocks LLM PR circuitandchisel/llm#113.