### PR TITLE
fix: restore legacy error code -30402 for backwards compatibility

### DIFF
--- a/packages/atxp-client/src/mppProtocolHandler.ts
+++ b/packages/atxp-client/src/mppProtocolHandler.ts
@@ -1,5 +1,5 @@
 import type { Logger, AccountId } from '@atxp/common';
-import { AuthorizationError } from '@atxp/common';
+import { AuthorizationError, PAYMENT_REQUIRED_ERROR_CODE } from '@atxp/common';
 import type { ProtocolHandler, ProtocolConfig } from './protocolHandler.js';
 import type { ProspectivePayment } from './types.js';
 import {
@@ -100,7 +100,9 @@ export class MPPProtocolHandler implements ProtocolHandler {
         parsed !== null &&
         typeof parsed.error === 'object' &&
         parsed.error !== null &&
-        parsed.error.code === MPP_ERROR_CODE
+        // Accept both MPP's -32042 and legacy ATXP's -30402 (servers currently
+        // send -30402 for backwards compat with old clients)
+        (parsed.error.code === MPP_ERROR_CODE || parsed.error.code === PAYMENT_REQUIRED_ERROR_CODE)
       ) {
         const challenges = parseMPPChallengesFromMCPError(parsed.error.data);
         if (challenges.length > 0) {

--- a/packages/atxp-mpp/src/mppChallenge.ts
+++ b/packages/atxp-mpp/src/mppChallenge.ts
@@ -3,10 +3,16 @@
  *
  * MPP challenges come in two forms:
  * 1. HTTP level: HTTP 402 with WWW-Authenticate: Payment header
- * 2. MCP level: JSON-RPC error with code -32042 containing MPP data
+ * 2. MCP level: JSON-RPC error with code -32042 (or -30402 for backwards compat)
  */
 
+// The MPP spec defines -32042 as the error code for payment challenges.
+// TODO: Once clients prior to v0.11.0 are phased out, servers can switch
+// from PAYMENT_REQUIRED_ERROR_CODE (-30402) back to MPP_ERROR_CODE (-32042).
 export const MPP_ERROR_CODE = -32042;
+
+// Legacy ATXP error code. Servers currently send this for backwards compat.
+const LEGACY_PAYMENT_ERROR_CODE = -30402;
 
 export interface MPPChallenge {
   id: string;
@@ -181,7 +187,7 @@ export async function hasMPPMCPError(response: Response): Promise<boolean> {
       parsed !== null &&
       typeof parsed.error === 'object' &&
       parsed.error !== null &&
-      parsed.error.code === MPP_ERROR_CODE
+      (parsed.error.code === MPP_ERROR_CODE || parsed.error.code === LEGACY_PAYMENT_ERROR_CODE)
     ) {
       const challenge = parseMPPFromMCPError(parsed.error.data);
       return challenge !== null;

--- a/packages/atxp-server/src/omniChallenge.ts
+++ b/packages/atxp-server/src/omniChallenge.ts
@@ -1,5 +1,5 @@
 import { McpError } from "@modelcontextprotocol/sdk/types.js";
-import { PAYMENT_REQUIRED_PREAMBLE, AuthorizationServerUrl, USDC_ADDRESSES, CAIP2_NETWORKS } from "@atxp/common";
+import { PAYMENT_REQUIRED_PREAMBLE, PAYMENT_REQUIRED_ERROR_CODE, AuthorizationServerUrl, USDC_ADDRESSES, CAIP2_NETWORKS } from "@atxp/common";
 import { MPP_ERROR_CODE } from "@atxp/mpp";
 import { BigNumber } from "bignumber.js";
 import type { OmniChallenge, X402PaymentRequirements, AtxpMcpChallengeData, MppChallengeData, X402PaymentOption } from "./protocol.js";
@@ -167,10 +167,18 @@ export function serializeMppHeader(challenge: MppChallengeData): string {
 /**
  * Create an omni-challenge MCP error containing challenge data for ALL protocols.
  *
- * Uses MPP's error code (-32042) as the unified payment-required code.
+ * Uses the legacy ATXP error code (-30402) for backwards compatibility with
+ * existing clients that only check for -30402. The MPP spec defines -32042
+ * (MPP_ERROR_CODE) but we can't use it yet — old SDK clients (<0.11.0) don't
+ * recognize -32042 and would silently ignore payment challenges.
+ *
+ * New SDK clients (>=0.10.x) accept both -30402 and -32042, so this works
+ * with both old and new clients. Once old clients are phased out, switch
+ * back to MPP_ERROR_CODE (-32042).
+ *
  * error.data contains both ATXP-MCP fields (paymentRequestId, paymentRequestUrl)
- * and MPP fields (data.mpp). Standard MPP clients detect -32042 + data.mpp.
- * ATXP clients detect -32042 + data.paymentRequestId (and also handle legacy -30402).
+ * and MPP fields (data.mpp). Standard MPP clients detect the code + data.mpp.
+ * ATXP clients detect the code + data.paymentRequestId.
  * X402 data is included as data.x402 for completeness but X402 is HTTP-only.
  */
 export function omniChallengeMcpError(
@@ -201,8 +209,10 @@ export function omniChallengeMcpError(
   }
 
   const amountText = chargeAmount ? ` You will be charged ${chargeAmount.toString()}.` : '';
+  // Use legacy -30402 (not MPP_ERROR_CODE -32042) for backwards compatibility.
+  // See function JSDoc for rationale. TODO: switch to MPP_ERROR_CODE once old clients are phased out.
   return new McpError(
-    MPP_ERROR_CODE,
+    PAYMENT_REQUIRED_ERROR_CODE,
     `${PAYMENT_REQUIRED_PREAMBLE}${amountText} Please pay at: ${atxpMcp.paymentRequestUrl} and then try again.`,
     data,
   );


### PR DESCRIPTION
## Summary

The omni-challenge server was sending `-32042` (MPP spec) which broke clients prior to v0.11.0 that only check for `-30402`.

**Server**: `omniChallengeMcpError` now sends `-30402` instead of `-32042`
**Client**: MPP handlers accept both `-32042` and `-30402`

Old clients (`<0.11.0`): only check `-30402` → **now works again**
New clients (`>=0.11.0`): check both codes → works with old and new servers

TODO comments mark where to switch back to `-32042` once old clients are phased out.

## How to test locally

```bash
cd sdk
npm run build && npm run build:dev

# Terminal 1: start resource server
npm run dev:resource

# Terminal 2: start accounts + auth (from their respective dirs)
cd ../accounts && npm run dev
cd ../auth && npm run dev

# Terminal 3: test with CLI
redis-cli SET "ff:protocol-flag" '"atxp"'
redis-cli SET "ff:use-local-ledger" '"true"'
npm run dev:cli

# Verify in output: "MCP payment error: code=-30402" (not -32042)
```

## Test plan
- [x] Typecheck passes
- [x] All workspace tests pass
- [x] Local E2E: client logs `code=-30402` and triggers payment flow
- [x] MPP protocol handler detects `-30402` from server

🤖 Generated with [Claude Code](https://claude.com/claude-code)