### PR TITLE
fix: only advertise protocols with actual challenge data

### DIFF
--- a/packages/atxp-base/src/baseAccount.ts
+++ b/packages/atxp-base/src/baseAccount.ts
@@ -103,7 +103,6 @@ export class BaseAccount implements Account {
         const httpClient = new x402HTTPClient(client);
 
         // Build PaymentRequired envelope from the enriched requirements
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const paymentRequired = {
           x402Version,
           accepts: [reqs],

--- a/packages/atxp-client/src/atxpAccountHandler.test.ts
+++ b/packages/atxp-client/src/atxpAccountHandler.test.ts
@@ -72,7 +72,7 @@ describe('ATXPAccountHandler', () => {
       expect(authorize).toHaveBeenCalledTimes(1);
       expect(authorize).toHaveBeenCalledWith(
         expect.objectContaining({
-          protocols: ['atxp', 'x402', 'mpp'],
+          protocols: ['atxp'],
           amount: expect.anything(),
         }),
       );

--- a/packages/atxp-client/src/atxpAccountHandler.ts
+++ b/packages/atxp-client/src/atxpAccountHandler.ts
@@ -58,11 +58,19 @@ export class ATXPAccountHandler implements ProtocolHandler {
     }
 
     // Delegate to account.authorize() → accounts /authorize/auto
-    logger.info('ATXPAccountHandler: delegating to account.authorize()');
+    // Only advertise protocols the server actually provided data for.
+    // Always include 'atxp' (needs only amount + destination).
+    // Include 'x402' only if the challenge contained x402 accepts.
+    // Include 'mpp' only if the challenge contained mpp challenges.
+    const protocols: Array<'atxp' | 'x402' | 'mpp'> = ['atxp'];
+    if (authorizeParams.paymentRequirements) protocols.push('x402');
+    if (authorizeParams.challenges) protocols.push('mpp');
+
+    logger.info(`ATXPAccountHandler: delegating to account.authorize() with protocols=[${protocols.join(',')}]`);
     let result;
     try {
       result = await account.authorize({
-        protocols: ['atxp', 'x402', 'mpp'],
+        protocols,
         amount: authorizeParams.amount ? new BigNumber(String(authorizeParams.amount)) : undefined,
         destination: authorizeParams.destination as string | undefined,
         paymentRequirements: authorizeParams.paymentRequirements,

--- a/packages/atxp-server/src/node/http.ts
+++ b/packages/atxp-server/src/node/http.ts
@@ -37,7 +37,7 @@ export async function parseMcpRequests(config: ATXPConfig, requestUrl: URL, req:
   return requests;
 }
 
-export async function parseBody(req: IncomingMessage, logger: Logger): Promise<unknown> {
+export async function parseBody(req: IncomingMessage, _logger: Logger): Promise<unknown> {
   try {
     const ct = req.headers["content-type"];
 

--- a/packages/atxp-x402/src/x402Wrapper.ts
+++ b/packages/atxp-x402/src/x402Wrapper.ts
@@ -211,7 +211,6 @@ export const wrapWithX402: FetchWrapper = (config: ClientArgs): FetchLike => {
       x402ClientInstance.register(network as `${string}:${string}`, scheme);
       const httpClient = new x402HTTPClient(x402ClientInstance);
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const paymentRequired = {
         x402Version: paymentChallenge.x402Version,
         accepts: [selectedPaymentRequirements],


### PR DESCRIPTION
## Summary
- `ATXPAccountHandler` was hardcoding `protocols: ['atxp', 'x402', 'mpp']` when calling `/authorize/auto`, regardless of what the MCP server's challenge actually contained
- When the server only sent a `paymentRequestUrl` (no inline x402/mpp data), `/authorize/auto` would select x402 via feature flag and fabricate `paymentRequirements` from the generic `receiver` field — an ATXP account ID — causing 403 "Destination not allowed for IOU conversion"
- Now the protocols list is derived from what `buildAuthorizeParams` actually extracted: always `atxp`, plus `x402` only if `paymentRequirements` exist, plus `mpp` only if `challenges` exist

## Companion PR
- circuitandchisel/accounts#674 — removes the fabrication code from `/authorize/auto` and whitelists the Music ATXP account ID

## Test plan
- [x] Reproduced the 403 locally against a local music MCP server with the old code
- [x] Verified the fix sends `protocols=[atxp]` when only ATXP challenge data is present
- [ ] End-to-end test with accounts whitelist change deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)