### PR TITLE
fix: clear detected credential after settlement to prevent double-settle

### DIFF
--- a/packages/atxp-server/src/atxpContext.ts
+++ b/packages/atxp-server/src/atxpContext.ts
@@ -79,6 +79,18 @@ export function setDetectedCredential(credential: DetectedCredential): void {
 }
 
 /**
+ * Clear the payment credential from the ATXP context after successful settlement.
+ * Prevents a second requirePayment() call in the same request from trying to
+ * settle the same already-consumed credential.
+ */
+export function clearDetectedCredential(): void {
+  const context = contextStorage.getStore();
+  if (context) {
+    context.detectedCredential = undefined;
+  }
+}
+
+/**
  * Get the pending payment challenge (set by omniChallengeMcpError).
  * Used by atxpExpress to rewrite wrapped tool errors into JSON-RPC errors.
  */

--- a/packages/atxp-server/src/requirePayment.ts
+++ b/packages/atxp-server/src/requirePayment.ts
@@ -1,7 +1,7 @@
 import { RequirePaymentConfig, extractNetworkFromAccountId, extractAddressFromAccountId, Network, AuthorizationServerUrl } from "@atxp/common";
 import { McpError } from "@modelcontextprotocol/sdk/types.js";
 import { BigNumber } from "bignumber.js";
-import { getATXPConfig, atxpAccountId, atxpToken, getDetectedCredential, setPendingPaymentChallenge } from "./atxpContext.js";
+import { getATXPConfig, atxpAccountId, atxpToken, getDetectedCredential, clearDetectedCredential, setPendingPaymentChallenge } from "./atxpContext.js";
 import { buildPaymentOptions, omniChallengeMcpError } from "./omniChallenge.js";
 import { getATXPResource } from "./atxpContext.js";
 import { ProtocolSettlement, type SettlementContext } from "./protocol.js";
@@ -50,6 +50,9 @@ export async function requirePayment(paymentConfig: RequirePaymentConfig): Promi
   const detectedCredential = getDetectedCredential();
   if (detectedCredential) {
     await settleDetectedCredential(config, detectedCredential, charge, destinationAccountId, paymentAmount);
+    // Clear the credential so a second requirePayment() call in the same request
+    // (e.g., image server's post-generation charge) doesn't try to re-settle it.
+    clearDetectedCredential();
     // After settlement, the ledger should be credited. Fall through to charge below.
   }
 


### PR DESCRIPTION
## Summary
- After `settleDetectedCredential()` succeeds, clears the credential from AsyncLocalStorage so a second `requirePayment()` call in the same request doesn't try to re-settle the same already-consumed credential
- Fixes settlement failures when tool handlers call `requirePayment()` multiple times (e.g., image server's pre-flight balance check + post-generation charge)
- Errors seen: "Transaction hash has already been used" (MPP/Tempo), "AlreadyProcessed" (Solana X402)

## Root cause
The image MCP server ([`circuitandchisel/image/src/tools.ts`](https://github.com/circuitandchisel/image/blob/main/src/tools.ts#L203)) calls `requirePayment()` twice per tool invocation:
1. Line 203: pre-flight balance check before expensive API call
2. Line 269: actual charge after image generation

On a retry request (with payment credential in headers), both calls read the same credential from ALS. The first settles it successfully, but the second tries to settle the same consumed credential — the on-chain transaction was already processed.

## Fix
Add `clearDetectedCredential()` and call it immediately after successful settlement in `requirePayment()`. The second call sees no credential and proceeds directly to `charge()`.

## Test plan
- [x] 184 server tests pass
- [ ] End-to-end test with image MCP server after SDK publish + deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)