### PR TITLE
fix: allow null txHash in SettleResult for already-settled retries

### DIFF
--- a/packages/atxp-express/src/atxpExpress.ts
+++ b/packages/atxp-express/src/atxpExpress.ts
@@ -150,7 +150,7 @@ export function atxpExpress(args: ATXPArgs): Router {
               detected.credential,
               context as Parameters<typeof settlement.settle>[2],
             );
-            logger.info(`Settled ${detected.protocol} in middleware: txHash=${result.txHash}, amount=${result.settledAmount}`);
+            logger.info(`Settled ${detected.protocol} in middleware: txHash=${result.txHash ?? '<already-settled>'}, amount=${result.settledAmount}`);
           } catch (error) {
             logger.error(`Middleware settlement failed for ${detected.protocol}: ${error instanceof Error ? error.message : String(error)}`);
             // Don't store the credential — it's already consumed/invalid.

--- a/packages/atxp-server/src/protocol.test.ts
+++ b/packages/atxp-server/src/protocol.test.ts
@@ -319,6 +319,31 @@ describe('ProtocolSettlement', () => {
       await expect(settlement.settle('x402', 'cred')).rejects.toThrow('Settlement failed for x402: 500');
     });
 
+    it('should pass through null txHash when auth reports already-settled', async () => {
+      // The auth server returns { txHash: null, alreadySettled: true, ... } on
+      // retries of an already-settled payload. The SDK should surface it as-is
+      // rather than crashing or forcing the type to string.
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          txHash: null,
+          settledAmount: '201000',
+          alreadySettled: true,
+          network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+          payer: '3FnrCCfHhZhEyeQd5Q69B1faqLvdHoG3WxUesZBBJ7M2',
+          sourceAccountId: 'atxp:atxp_acct_6qB245zVIJeSiIHi8xPmY',
+        }),
+      });
+
+      const payload = { signature: '0xabc' };
+      const credential = Buffer.from(JSON.stringify(payload)).toString('base64');
+      const result = await settlement.settle('x402', credential, { paymentRequirements: { network: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp' } });
+
+      expect(result.txHash).toBeNull();
+      expect(result.settledAmount).toBe('201000');
+      expect(result.alreadySettled).toBe(true);
+    });
+
     describe('X402 multi-chain accept routing', () => {
       const multiChainReqs = {
         x402Version: 2,

--- a/packages/atxp-server/src/protocol.ts
+++ b/packages/atxp-server/src/protocol.ts
@@ -106,10 +106,16 @@ export type VerifyResult = {
 
 /**
  * Result of settling a payment.
+ *
+ * `txHash` is null when the auth server reports the payment was already settled
+ * by a prior call (HTTP retry after a successful settle). The original tx hash
+ * is not carried in that response; callers that need it must look it up by
+ * other means (payer / amount / destination).
  */
 export type SettleResult = {
-  txHash: string;
+  txHash: string | null;
   settledAmount: string;
+  alreadySettled?: boolean;
 };
 
 /**
@@ -230,7 +236,7 @@ export class ProtocolSettlement {
     }
 
     const result = await response.json() as SettleResult;
-    this.logger.info(`Settled ${protocol}: txHash=${result.txHash}, amount=${result.settledAmount}`);
+    this.logger.info(`Settled ${protocol}: txHash=${result.txHash ?? '<already-settled>'}, amount=${result.settledAmount}`);
     return result;
   }
 


### PR DESCRIPTION
## Summary

Loosens `SettleResult.txHash` from `string` to `string | null`, adds an optional `alreadySettled` flag, and updates the two log interpolations that reference `txHash` to render `<already-settled>` when it's null.

## Why

A companion auth PR ([circuitandchisel/auth#new](https://github.com/circuitandchisel/auth/pull/new/fix/x402-duplicate-transaction-200)) adds a carve-out on `POST /settle/x402` that returns `200 OK` with `{ alreadySettled: true, txHash: null, ... }` when the CDP facilitator reports `duplicate transaction` on a retry of an already-settled payload. Today `SettleResult.txHash` is typed as non-nullable `string`, which would be a lie the moment that auth change ships.

Nothing in the SDK reads `txHash` beyond two `logger.info` template-string interpolations (`protocol.ts:233`, `atxpExpress.ts:153`), so runtime behavior is unchanged on the happy path. This PR just tells the truth at the type layer and makes the log line render nicely when it's null.

## What changed

- `packages/atxp-server/src/protocol.ts` — `SettleResult.txHash: string` → `string | null`, add optional `alreadySettled?: boolean`, and update log interpolation to `${result.txHash ?? '<already-settled>'}`.
- `packages/atxp-express/src/atxpExpress.ts` — same log-interpolation nil-coalesce on the middleware's `txHash=...` log line.
- `packages/atxp-server/src/protocol.test.ts` — one new test: auth returns `{ txHash: null, alreadySettled: true, ... }`, SDK surfaces it as-is without crashing.

## Ordering / deploy safety

- SDK-first deploy (this PR first, auth second): SDK types allow null but auth never returns null yet — safe.
- Auth-first deploy (auth PR first, SDK still on 0.11.8): auth returns `txHash: null`, SDK's old type casts `as SettleResult` — JS runtime is fine (`${null}` renders as `"null"`, ugly but no crash), the only consumers are log lines. Also safe.
- Either order works; no coordinated release needed.

## Test plan

- [x] `npx vitest run src/protocol.test.ts` (atxp-server) — 26 passed (25 original + 1 new)
- [x] `npx vitest run` (atxp-express) — 45 passed
- [x] Typecheck clean in main checkout for both packages
- [x] Lint clean on changed files
- [ ] Full CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)