### PR TITLE
fix: update @atxp/mpp and @atxp/tempo cross-deps in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,7 +75,9 @@ jobs:
 
           # Update cross-package dependencies to match new version
           npm pkg set dependencies."@atxp/common"=$VERSION -w packages/atxp-client
+          npm pkg set dependencies."@atxp/mpp"=$VERSION -w packages/atxp-client
           npm pkg set dependencies."@atxp/common"=$VERSION -w packages/atxp-server
+          npm pkg set dependencies."@atxp/mpp"=$VERSION -w packages/atxp-server
           npm pkg set dependencies."@atxp/common"=$VERSION -w packages/atxp-sqlite
           npm pkg set dependencies."@atxp/common"=$VERSION -w packages/atxp-redis
           npm pkg set dependencies."@atxp/common"=$VERSION -w packages/atxp-base
@@ -86,6 +88,8 @@ jobs:
           npm pkg set dependencies."@atxp/client"=$VERSION -w packages/atxp-worldchain
           npm pkg set dependencies."@atxp/common"=$VERSION -w packages/atxp-polygon
           npm pkg set dependencies."@atxp/client"=$VERSION -w packages/atxp-polygon
+          npm pkg set dependencies."@atxp/common"=$VERSION -w packages/atxp-tempo
+          npm pkg set dependencies."@atxp/client"=$VERSION -w packages/atxp-tempo
           npm pkg set dependencies."@atxp/server"=$VERSION -w packages/atxp-express
           npm pkg set dependencies."@atxp/common"=$VERSION -w packages/atxp-cloudflare
           npm pkg set dependencies."@atxp/server"=$VERSION -w packages/atxp-cloudflare

--- a/package-lock.json
+++ b/package-lock.json
@@ -15149,38 +15149,6 @@
         "vitest": "^4.0.16"
       }
     },
-    "packages/atxp-base/node_modules/@atxp/client": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@atxp/client/-/client-0.11.7.tgz",
-      "integrity": "sha512-MVdzEDv7D/ZRr/9xa5Peuw/SUG7y7XJk+WREa6seEGfzTlJ3d/SHpKG/qLUZk9G3/1+IALEAguZjlRZoPSnA7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@atxp/common": "0.11.7",
-        "@atxp/mpp": "0.11.7",
-        "@modelcontextprotocol/sdk": "^1.15.0",
-        "@x402/core": "^2.9.0",
-        "@x402/evm": "^2.9.0",
-        "bignumber.js": "^9.3.0",
-        "oauth4webapi": "^3.8.3"
-      },
-      "peerDependencies": {
-        "expo-crypto": ">=14.0.0",
-        "react-native-url-polyfill": "^3.0.0"
-      }
-    },
-    "packages/atxp-base/node_modules/@atxp/common": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@atxp/common/-/common-0.11.7.tgz",
-      "integrity": "sha512-9iAOCsjU3ztzKm75uQlEFF9lch7xpFf9ySJQ58mYyCE2x6MB7SuMnGJ9hlGB5J/PFbqdyzeW9YffG4hJDu6kng==",
-      "license": "MIT",
-      "dependencies": {
-        "bignumber.js": "^9.3.0",
-        "jose": "^6.0.11",
-        "oauth4webapi": "^3.8.3",
-        "tweetnacl": "^1.0.3",
-        "tweetnacl-util": "^0.15.1"
-      }
-    },
     "packages/atxp-base/node_modules/@atxp/mpp": {
       "version": "0.11.7",
       "resolved": "https://registry.npmjs.org/@atxp/mpp/-/mpp-0.11.7.tgz",
@@ -15193,7 +15161,7 @@
       "license": "MIT",
       "dependencies": {
         "@atxp/common": "0.11.8",
-        "@atxp/mpp": "0.11.7",
+        "@atxp/mpp": "0.11.8",
         "@modelcontextprotocol/sdk": "^1.15.0",
         "@x402/core": "^2.9.0",
         "@x402/evm": "^2.9.0",
@@ -15261,12 +15229,6 @@
         "agents": "^0.3.3"
       }
     },
-    "packages/atxp-cloudflare/node_modules/@atxp/mpp": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@atxp/mpp/-/mpp-0.11.7.tgz",
-      "integrity": "sha512-VnZcFAxlE1T8F9ssSRVk2BYP2DTPQbjmlNln1pPkbDk5fVhgQ9Il/yqkgo2tEPT8wX9CCBLd1v6YYLTAmh7Wlw==",
-      "license": "MIT"
-    },
     "packages/atxp-common": {
       "name": "@atxp/common",
       "version": "0.11.8",
@@ -15311,25 +15273,6 @@
         "express": "^5.0.0"
       }
     },
-    "packages/atxp-express/node_modules/@atxp/common": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@atxp/common/-/common-0.11.7.tgz",
-      "integrity": "sha512-9iAOCsjU3ztzKm75uQlEFF9lch7xpFf9ySJQ58mYyCE2x6MB7SuMnGJ9hlGB5J/PFbqdyzeW9YffG4hJDu6kng==",
-      "license": "MIT",
-      "dependencies": {
-        "bignumber.js": "^9.3.0",
-        "jose": "^6.0.11",
-        "oauth4webapi": "^3.8.3",
-        "tweetnacl": "^1.0.3",
-        "tweetnacl-util": "^0.15.1"
-      }
-    },
-    "packages/atxp-express/node_modules/@atxp/mpp": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@atxp/mpp/-/mpp-0.11.7.tgz",
-      "integrity": "sha512-VnZcFAxlE1T8F9ssSRVk2BYP2DTPQbjmlNln1pPkbDk5fVhgQ9Il/yqkgo2tEPT8wX9CCBLd1v6YYLTAmh7Wlw==",
-      "license": "MIT"
-    },
     "packages/atxp-mpp": {
       "name": "@atxp/mpp",
       "version": "0.11.8",
@@ -15368,12 +15311,6 @@
         "vitest": "^4.0.16"
       }
     },
-    "packages/atxp-polygon/node_modules/@atxp/mpp": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@atxp/mpp/-/mpp-0.11.7.tgz",
-      "integrity": "sha512-VnZcFAxlE1T8F9ssSRVk2BYP2DTPQbjmlNln1pPkbDk5fVhgQ9Il/yqkgo2tEPT8wX9CCBLd1v6YYLTAmh7Wlw==",
-      "license": "MIT"
-    },
     "packages/atxp-redis": {
       "name": "@atxp/redis",
       "version": "0.11.8",
@@ -15397,7 +15334,7 @@
       "license": "MIT",
       "dependencies": {
         "@atxp/common": "0.11.8",
-        "@atxp/mpp": "0.11.7",
+        "@atxp/mpp": "0.11.8",
         "@modelcontextprotocol/sdk": "^1.15.0",
         "bignumber.js": "^9.3.0",
         "oauth4webapi": "^3.8.3"
@@ -15414,12 +15351,6 @@
       "peerDependencies": {
         "content-type": "^1.0.5"
       }
-    },
-    "packages/atxp-server/node_modules/@atxp/mpp": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@atxp/mpp/-/mpp-0.11.7.tgz",
-      "integrity": "sha512-VnZcFAxlE1T8F9ssSRVk2BYP2DTPQbjmlNln1pPkbDk5fVhgQ9Il/yqkgo2tEPT8wX9CCBLd1v6YYLTAmh7Wlw==",
-      "license": "MIT"
     },
     "packages/atxp-solana": {
       "name": "@atxp/solana",
@@ -15441,12 +15372,6 @@
         "typescript": "^5.7.3",
         "vitest": "^4.0.16"
       }
-    },
-    "packages/atxp-solana/node_modules/@atxp/mpp": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@atxp/mpp/-/mpp-0.11.7.tgz",
-      "integrity": "sha512-VnZcFAxlE1T8F9ssSRVk2BYP2DTPQbjmlNln1pPkbDk5fVhgQ9Il/yqkgo2tEPT8wX9CCBLd1v6YYLTAmh7Wlw==",
-      "license": "MIT"
     },
     "packages/atxp-sqlite": {
       "name": "@atxp/sqlite",
@@ -15471,8 +15396,8 @@
       "version": "0.11.8",
       "license": "MIT",
       "dependencies": {
-        "@atxp/client": "0.11.7",
-        "@atxp/common": "0.11.7",
+        "@atxp/client": "0.11.8",
+        "@atxp/common": "0.11.8",
         "bignumber.js": "^9.3.0",
         "viem": "^2.34.0"
       },
@@ -15483,38 +15408,6 @@
         "eslint": "^9.32.0",
         "typescript": "^5.7.3",
         "vitest": "^4.0.16"
-      }
-    },
-    "packages/atxp-tempo/node_modules/@atxp/client": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@atxp/client/-/client-0.11.7.tgz",
-      "integrity": "sha512-MVdzEDv7D/ZRr/9xa5Peuw/SUG7y7XJk+WREa6seEGfzTlJ3d/SHpKG/qLUZk9G3/1+IALEAguZjlRZoPSnA7Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@atxp/common": "0.11.7",
-        "@atxp/mpp": "0.11.7",
-        "@modelcontextprotocol/sdk": "^1.15.0",
-        "@x402/core": "^2.9.0",
-        "@x402/evm": "^2.9.0",
-        "bignumber.js": "^9.3.0",
-        "oauth4webapi": "^3.8.3"
-      },
-      "peerDependencies": {
-        "expo-crypto": ">=14.0.0",
-        "react-native-url-polyfill": "^3.0.0"
-      }
-    },
-    "packages/atxp-tempo/node_modules/@atxp/common": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@atxp/common/-/common-0.11.7.tgz",
-      "integrity": "sha512-9iAOCsjU3ztzKm75uQlEFF9lch7xpFf9ySJQ58mYyCE2x6MB7SuMnGJ9hlGB5J/PFbqdyzeW9YffG4hJDu6kng==",
-      "license": "MIT",
-      "dependencies": {
-        "bignumber.js": "^9.3.0",
-        "jose": "^6.0.11",
-        "oauth4webapi": "^3.8.3",
-        "tweetnacl": "^1.0.3",
-        "tweetnacl-util": "^0.15.1"
       }
     },
     "packages/atxp-tempo/node_modules/@atxp/mpp": {
@@ -15549,12 +15442,6 @@
         "vitest": "^4.0.16"
       }
     },
-    "packages/atxp-worldchain/node_modules/@atxp/mpp": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@atxp/mpp/-/mpp-0.11.7.tgz",
-      "integrity": "sha512-VnZcFAxlE1T8F9ssSRVk2BYP2DTPQbjmlNln1pPkbDk5fVhgQ9Il/yqkgo2tEPT8wX9CCBLd1v6YYLTAmh7Wlw==",
-      "license": "MIT"
-    },
     "packages/atxp-x402": {
       "name": "@atxp/x402",
       "version": "0.11.8",
@@ -15576,12 +15463,6 @@
         "typescript": "^5.7.3",
         "vitest": "^4.0.16"
       }
-    },
-    "packages/atxp-x402/node_modules/@atxp/mpp": {
-      "version": "0.11.7",
-      "resolved": "https://registry.npmjs.org/@atxp/mpp/-/mpp-0.11.7.tgz",
-      "integrity": "sha512-VnZcFAxlE1T8F9ssSRVk2BYP2DTPQbjmlNln1pPkbDk5fVhgQ9Il/yqkgo2tEPT8wX9CCBLd1v6YYLTAmh7Wlw==",
-      "license": "MIT"
     }
   }
 }

--- a/packages/atxp-client/package.json
+++ b/packages/atxp-client/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@atxp/common": "0.11.8",
-    "@atxp/mpp": "0.11.7",
+    "@atxp/mpp": "0.11.8",
     "@modelcontextprotocol/sdk": "^1.15.0",
     "@x402/core": "^2.9.0",
     "@x402/evm": "^2.9.0",

--- a/packages/atxp-server/package.json
+++ b/packages/atxp-server/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@atxp/common": "0.11.8",
-    "@atxp/mpp": "0.11.7",
+    "@atxp/mpp": "0.11.8",
     "@modelcontextprotocol/sdk": "^1.15.0",
     "bignumber.js": "^9.3.0",
     "oauth4webapi": "^3.8.3"

--- a/packages/atxp-tempo/package.json
+++ b/packages/atxp-tempo/package.json
@@ -33,8 +33,8 @@
     "pack:dry": "npm pack --dry-run"
   },
   "dependencies": {
-    "@atxp/client": "0.11.7",
-    "@atxp/common": "0.11.7",
+    "@atxp/client": "0.11.8",
+    "@atxp/common": "0.11.8",
     "bignumber.js": "^9.3.0",
     "viem": "^2.34.0"
   },


### PR DESCRIPTION
## Summary
- Release workflow bumps `atxp-mpp` and `atxp-tempo` versions but never updates cross-package deps onto them. As a result, 0.11.8 published with `atxp-client`/`atxp-server` still pinning `@atxp/mpp@0.11.7` and `atxp-tempo` still pinning `@atxp/client@0.11.7` / `@atxp/common@0.11.7`. (Note: 0.11.7 and 0.11.8 of `@atxp/mpp` are code-identical, so installed deps still resolve correctly at runtime — this is a hygiene fix.)
- Adds 4 missing `npm pkg set` lines so the next release sets them correctly.
- Syncs the current package.jsons to 0.11.8 so the source tree is internally consistent.

## Test plan
- [ ] Verify workflow diff adds the 4 expected lines (`@atxp/mpp` for client/server; `@atxp/common` and `@atxp/client` for tempo)
- [ ] On next release, confirm `atxp-client`, `atxp-server`, `atxp-tempo` published with matching `@atxp/*` deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)