### PR TITLE
Stabilize release-flaky package tests

### DIFF
--- a/packages/atxp-client/package.json
+++ b/packages/atxp-client/package.json
@@ -28,7 +28,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "test": "vitest run",
+    "test": "vitest run --fileParallelism=false",
     "prepack": "npm run build && npm run typecheck",
     "pack:dry": "npm pack --dry-run"
   },

--- a/packages/atxp-express/package.json
+++ b/packages/atxp-express/package.json
@@ -28,7 +28,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "test": "vitest run",
+    "test": "vitest run --fileParallelism=false",
     "prepack": "npm run build && npm run typecheck",
     "pack:dry": "npm pack --dry-run"
   },

--- a/packages/atxp-server/package.json
+++ b/packages/atxp-server/package.json
@@ -33,7 +33,7 @@
     "typecheck": "tsc --noEmit",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "test": "vitest run",
+    "test": "vitest run --fileParallelism=false",
     "prepack": "npm run build && npm run typecheck && rm -rf dist/node_modules dist/_virtual",
     "pack:dry": "npm pack --dry-run"
   },


### PR DESCRIPTION
## Summary
- run Vitest test files serially only for atxp-express, atxp-client, and atxp-server
- targets the packages that failed during the v0.11.9 release rerun
- leaves other workspace package test parallelism unchanged

## Validation
- npm test -w packages/atxp-express
- npm test -w packages/atxp-client
- npm test -w packages/atxp-server
- npm test