### PR TITLE
Fix release workspace version bump

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,24 +54,26 @@ jobs:
 
           echo "Updating version from $CURRENT_VERSION to $VERSION"
 
-          # Update root package version
-          npm version $VERSION --no-git-tag-version
+          # Update package versions without running npm version's implicit install
+          # per workspace. The implicit installs can create nested packages/*/node_modules
+          # entries that shadow local workspaces with already-published packages.
+          npm pkg set version=$VERSION
 
           # Update all workspace package versions
-          npm version $VERSION --no-git-tag-version -w packages/atxp-common
-          npm version $VERSION --no-git-tag-version -w packages/atxp-sqlite
-          npm version $VERSION --no-git-tag-version -w packages/atxp-redis
-          npm version $VERSION --no-git-tag-version -w packages/atxp-server
-          npm version $VERSION --no-git-tag-version -w packages/atxp-client
-          npm version $VERSION --no-git-tag-version -w packages/atxp-base
-          npm version $VERSION --no-git-tag-version -w packages/atxp-solana
-          npm version $VERSION --no-git-tag-version -w packages/atxp-worldchain
-          npm version $VERSION --no-git-tag-version -w packages/atxp-polygon
-          npm version $VERSION --no-git-tag-version -w packages/atxp-express
-          npm version $VERSION --no-git-tag-version -w packages/atxp-cloudflare
-          npm version $VERSION --no-git-tag-version -w packages/atxp-x402
-          npm version $VERSION --no-git-tag-version -w packages/atxp-mpp
-          npm version $VERSION --no-git-tag-version -w packages/atxp-tempo
+          npm pkg set version=$VERSION -w packages/atxp-common
+          npm pkg set version=$VERSION -w packages/atxp-sqlite
+          npm pkg set version=$VERSION -w packages/atxp-redis
+          npm pkg set version=$VERSION -w packages/atxp-server
+          npm pkg set version=$VERSION -w packages/atxp-client
+          npm pkg set version=$VERSION -w packages/atxp-base
+          npm pkg set version=$VERSION -w packages/atxp-solana
+          npm pkg set version=$VERSION -w packages/atxp-worldchain
+          npm pkg set version=$VERSION -w packages/atxp-polygon
+          npm pkg set version=$VERSION -w packages/atxp-express
+          npm pkg set version=$VERSION -w packages/atxp-cloudflare
+          npm pkg set version=$VERSION -w packages/atxp-x402
+          npm pkg set version=$VERSION -w packages/atxp-mpp
+          npm pkg set version=$VERSION -w packages/atxp-tempo
 
           # Update cross-package dependencies to match new version
           npm pkg set dependencies."@atxp/common"=$VERSION -w packages/atxp-client


### PR DESCRIPTION
## Summary
- replace workspace `npm version` calls in the release workflow with `npm pkg set version`
- avoids implicit workspace-local installs that can create nested `packages/*/node_modules`
- keeps the final `npm install` so the lockfile is regenerated after versions and internal dependency ranges are updated

## Why
The v0.11.9 release rerun checked out main but failed tests because release-time workspace versioning created nested package installs that shadowed local workspaces with already-published @atxp packages. That made tests import stale 0.11.8 code during the 0.11.9 release.

## Validation
- Simulated the release version-bump step in /tmp using `npm pkg set version=0.11.9` and confirmed `@atxp/client` resolves `@atxp/common@0.11.9` to the local workspace
- `npx -y -p node@22 -p npm@10 npm run build` in the simulated release worktree
- `npx -y -p node@22 -p npm@10 npm test -w packages/atxp-client`
- `npx -y -p node@22 -p npm@10 npm test -w packages/atxp-express`
- `npx -y -p node@22 -p npm@10 npm test -w packages/atxp-server`