### PR TITLE
feat(x402): Phase 6 — thread paymentRequestId to authorize (Base)

### DIFF
--- a/packages/atxp-client/src/atxpAccountHandler.ts
+++ b/packages/atxp-client/src/atxpAccountHandler.ts
@@ -76,6 +76,7 @@ export class ATXPAccountHandler implements ProtocolHandler {
         paymentRequirements: authorizeParams.paymentRequirements,
         challenge: authorizeParams.challenge,
         challenges: authorizeParams.challenges as unknown[] | undefined,
+        paymentRequestId: typeof challengeData.paymentRequestId === 'string' ? challengeData.paymentRequestId : undefined,
       });
     } catch (error) {
       logger.error(`ATXPAccountHandler: authorize failed: ${error instanceof Error ? error.message : String(error)}`);

--- a/packages/atxp-client/src/x402ProtocolHandler.ts
+++ b/packages/atxp-client/src/x402ProtocolHandler.ts
@@ -149,6 +149,7 @@ export class X402ProtocolHandler implements ProtocolHandler {
         protocols: ['x402'],
         destination: url,
         paymentRequirements: enrichedRequirements,
+        paymentRequestId: paymentChallenge.paymentRequestId,
       });
       const paymentHeader = authorizeResult.credential;
 

--- a/packages/atxp-common/src/atxpAccount.ts
+++ b/packages/atxp-common/src/atxpAccount.ts
@@ -339,6 +339,8 @@ export class ATXPAccount implements Account {
     body.currency = 'USDC';
     // X402 fields
     if (params.paymentRequirements) body.paymentRequirements = params.paymentRequirements;
+    // Phase 6: lets accounts key the X402 cap reservation to the challenge so it releases on settle.
+    if (params.paymentRequestId) body.paymentRequestId = params.paymentRequestId;
     // MPP fields
     if (params.challenges) body.challenges = params.challenges;
     if (params.challenge) body.challenge = params.challenge;

--- a/packages/atxp-common/src/types.ts
+++ b/packages/atxp-common/src/types.ts
@@ -208,6 +208,11 @@ export interface AuthorizeParams {
   challenge?: unknown;
   /** MPP: array of challenges from multi-chain omni-challenge (preferred) */
   challenges?: unknown[];
+  /**
+   * The challenge's payment-request id. Threaded to accounts at authorize so it can key the
+   * X402 binding cap reservation (upto sessions) to it and release it on settle (Phase 6).
+   */
+  paymentRequestId?: string;
 }
 
 export interface AuthorizeResult {


### PR DESCRIPTION
## What
Phase 6 (X402 binding reservation + release), SDK side. Pairs with **accounts circuitandchisel/accounts#852** and **auth circuitandchisel/auth#281**.

accounts keys the binding X402 cap reservation (`upto` sessions) to the challenge's `paymentRequestId` and releases it at settle. This threads that id through `authorize` so accounts can store the reservation handle against it.

## Changes
- `AuthorizeParams.paymentRequestId` (optional).
- `ATXPAccount.authorize` sends it in the `/authorize/auto` request body.
- Passed from both call sites — the omni handler (`challengeData.paymentRequestId`) and the x402 handler (`paymentChallenge.paymentRequestId`).

## Compatibility
Additive and backwards-compatible: the field is optional, so an older accounts simply ignores it and the reservation falls back to TTL-based release. No behavioral change to existing flows. `npm run build` clean; atxp-client + atxp-common unit tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
